### PR TITLE
Apply patches Rendering of accent symbols and Loading of predefined formulas

### DIFF
--- a/WpfMath/Data/PredefinedTexFormulas.xml
+++ b/WpfMath/Data/PredefinedTexFormulas.xml
@@ -20,7 +20,7 @@
 
   <Formula name="hbar" enabled="true">
     <CreateFormula name="f">
-      <Argument type="string" value="\bar" />
+      <Argument type="string" value="\bar{}" />
     </CreateFormula>
     <MethodInvocation name="AddStrut" formula="f">
       <Argument type="Unit" value="Mu" />
@@ -154,14 +154,14 @@
 
   <!-- Macros -->
 
-  <Formula name="left" enabled="true">
+  <Formula name="left" enabled="false">
     <CreateFormula name="f">
       <Argument type="string" value="\left" />
     </CreateFormula>
     <Return name="f" />
   </Formula>
 
-  <Formula name="right" enabled="true">
+  <Formula name="right" enabled="false">
     <CreateFormula name="f">
       <Argument type="string" value="\right" />
     </CreateFormula>

--- a/WpfMath/PredefinedTexFormulasParser.cs
+++ b/WpfMath/PredefinedTexFormulasParser.cs
@@ -41,7 +41,7 @@ namespace WpfMath
             actionParsers.Add("MethodInvocation", new MethodInvocationParser());
             actionParsers.Add("Return", new ReturnParser());
 
-            argValueParsers.Add("TeXFormula", new TeXFormulaValueParser());
+            argValueParsers.Add("Formula", new TeXFormulaValueParser());
             argValueParsers.Add("string", new StringValueParser());
             argValueParsers.Add("double", new DoubleValueParser());
             argValueParsers.Add("int", new IntValueParser());
@@ -95,7 +95,7 @@ namespace WpfMath
             var rootEnabled = rootElement.AttributeBooleanValue("enabled", true);
             if (rootEnabled)
             {
-                foreach (var formulaElement in rootElement.Elements("TeXFormula"))
+                foreach (var formulaElement in rootElement.Elements("Formula"))
                 {
                     var enabled = formulaElement.AttributeBooleanValue("enabled", true);
                     if (enabled)

--- a/WpfMath/PredefinedTexFormulasParser.cs
+++ b/WpfMath/PredefinedTexFormulasParser.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using System.Text;
@@ -202,7 +203,7 @@ namespace WpfMath
 
             public override object Parse(string value, string type)
             {
-                return double.Parse(value);
+                return double.Parse(value, CultureInfo.InvariantCulture);
             }
         }
 
@@ -242,7 +243,7 @@ namespace WpfMath
 
             public override object Parse(string value, string type)
             {
-                return int.Parse(value);
+                return int.Parse(value, CultureInfo.InvariantCulture);
             }
         }
 

--- a/WpfMath/TexFormulaParser.cs
+++ b/WpfMath/TexFormulaParser.cs
@@ -322,7 +322,16 @@ namespace WpfMath
             {
                 // Symbol was found.
 
-                formula.Add(AttachScripts(formula, value, ref position, symbolAtom));
+                if (symbolAtom.Type == TexAtomType.Accent)
+                {
+                    TexFormulaHelper helper = new TexFormulaHelper(formula);
+                    TexFormula accentFormula = ReadScript(formula, value, ref position);
+                    helper.AddAccent(accentFormula, symbolAtom.Name);
+                }
+                else
+                {
+                    formula.Add(AttachScripts(formula, value, ref position, symbolAtom));
+                }
             }
             else if (predefinedFormula != null)
             {


### PR DESCRIPTION
Thanks to Marc Palmans.

[Rendering of accent symbols](https://bugs.launchpad.net/wpf-math/+bug/1033830)

> Accent symbols are rendered separately instead of above other characters.
> The following patch appears to fix this issue but someone with more knowledge of the source code and latex should check it.

[Loading of predefined formulas](https://bugs.launchpad.net/wpf-math/+bug/1052586)

> I fixed some issues regarding the loading of predefinedformulas.xml Everything should work except \left and \right, but I think we should use TexFormulaHelper.AddEmbraced to do this. I've temporarily disabled those in the xml file.

## Example:

before patches
![hbar before](https://cloud.githubusercontent.com/assets/832449/22853388/97ef938e-f06e-11e6-8033-87c5d69ac4b7.PNG)

after patches
![hbar after](https://cloud.githubusercontent.com/assets/832449/22853392/a21b55fa-f06e-11e6-8747-b9350f2cd440.PNG)

#3 

