### PR TITLE
Apply patch Feature: Render geometry & output as SVG

### DIFF
--- a/WpfMath.Example/MainWindow.xaml
+++ b/WpfMath.Example/MainWindow.xaml
@@ -24,8 +24,15 @@
 
         <DockPanel Margin="10" Grid.Row="0" Grid.Column="0">
 
-            <Button Name="renderButton" Margin="10,0,0,0" HorizontalAlignment="Right" VerticalAlignment="Stretch" Content="_Render" IsDefault="True" Click="renderButton_Click" DockPanel.Dock="Right"/>
-
+            <Grid DockPanel.Dock="Right">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition/>
+                    <ColumnDefinition/>
+                </Grid.ColumnDefinitions>
+                <Button Name="renderButton" Grid.Column="0" Margin="10,0,0,0" HorizontalAlignment="Right" VerticalAlignment="Stretch" Content="_Render" IsDefault="True" Click="renderButton_Click"/>
+                <Button Name="saveButton" Grid.Column="1" Margin="10,0,0,0" HorizontalAlignment="Right" VerticalAlignment="Stretch" Content="_Save" Click="saveButton_Click"/>
+            </Grid>
+                
             <TextBox Name="inputTextBox" HorizontalAlignment="Stretch" VerticalAlignment="Stretch"/>
 
         </DockPanel>

--- a/WpfMath.Example/MainWindow.xaml.cs
+++ b/WpfMath.Example/MainWindow.xaml.cs
@@ -24,7 +24,7 @@ namespace WpfMath.Example
             InitializeComponent();
         }
 
-        private TexFormula parseFormula(string input)
+        private TexFormula ParseFormula(string input)
         {
             // Create formula object from input text.
             TexFormula formula = null;
@@ -44,7 +44,7 @@ namespace WpfMath.Example
         private void renderButton_Click(object sender, RoutedEventArgs e)
         {
             // Create formula object from input text.
-            var formula = parseFormula(this.inputTextBox.Text);
+            var formula = ParseFormula(this.inputTextBox.Text);
             if (formula == null) return;
 
             // Render formula to visual.
@@ -63,7 +63,7 @@ namespace WpfMath.Example
         private void saveButton_Click(object sender, RoutedEventArgs e)
         {
             // Create formula object from input text.
-            var formula = parseFormula(this.inputTextBox.Text);
+            var formula = ParseFormula(this.inputTextBox.Text);
             if (formula == null) return;
 
             // Render formula to geometry.         
@@ -84,12 +84,24 @@ namespace WpfMath.Example
                 case 1:
                     var converter = new SVGConverter();
                     var svgText = converter.ConvertGeometry(geometry);
-                    System.IO.File.WriteAllText(filename, svgText);
+                    var fileText = AddSVGHeader(svgText);
+                    System.IO.File.WriteAllText(filename, fileText);
                     break;
                 default:
                     return;
             }
         }
+
+        private string AddSVGHeader(string svgText)
+        {
+            var builder = new StringBuilder();
+            builder.AppendLine("<?xml version=\"1.0\" encoding=\"UTF-8\" ?>")
+                .AppendLine("<svg xmlns=\"http://www.w3.org/2000/svg\" version=\"1.1\" >")
+                .AppendLine(svgText)
+                .AppendLine("</svg>");
+
+            return builder.ToString();
+        } 
 
         private void Window_Loaded(object sender, RoutedEventArgs e)
         {

--- a/WpfMath/Box.cs
+++ b/WpfMath/Box.cs
@@ -88,6 +88,11 @@ namespace WpfMath
             }
         }
 
+        public virtual void RenderGeometry(GeometryGroup geometry, double scale, double x, double y)
+        {
+
+        }
+
         public virtual void Add(Box box)
         {
             this.children.Add(box);

--- a/WpfMath/CharBox.cs
+++ b/WpfMath/CharBox.cs
@@ -25,15 +25,32 @@ namespace WpfMath
             private set;
         }
 
-        public override void Draw(DrawingContext drawingContext, double scale, double x, double y)
+        private GlyphRun GetGlyphRun(double scale, double x, double y)
         {
-            // Draw character at given position.
             var typeface = this.Character.Font;
             var glyphIndex = typeface.CharacterToGlyphMap[this.Character.Character];
             var glyphRun = new GlyphRun(typeface, 0, false, this.Character.Size * scale,
                 new ushort[] { glyphIndex }, new Point(x * scale, y * scale),
                 new double[] { typeface.AdvanceWidths[glyphIndex] }, null, null, null, null, null, null);
+            return glyphRun;
+
+        }
+
+        public override void Draw(DrawingContext drawingContext, double scale, double x, double y)
+        {
+            GlyphRun glyphRun = GetGlyphRun(scale, x, y);
+
+            // Draw character at given position.
             drawingContext.DrawGlyphRun(this.Foreground ?? Brushes.Black, glyphRun);
+        }
+
+        public override void RenderGeometry(GeometryGroup geometry, double scale, double x, double y)
+        {
+            GlyphRun glyphRun = GetGlyphRun(scale, x, y);
+
+            GeometryGroup geoGroup = glyphRun.BuildGeometry() as GeometryGroup;
+            PathGeometry pg = geoGroup.GetFlattenedPathGeometry();
+            geometry.Children.Add(pg);
         }
 
         public override int GetLastFontId()

--- a/WpfMath/HorizontalBox.cs
+++ b/WpfMath/HorizontalBox.cs
@@ -73,6 +73,16 @@ namespace WpfMath
             }
         }
 
+        public override void RenderGeometry(GeometryGroup geometry, double scale, double x, double y)
+        {
+            var curX = x;
+            foreach (var box in this.Children)
+            {
+                box.RenderGeometry(geometry, scale, curX, y + box.Shift);
+                curX += box.Width;
+            }
+        }
+
         public override int GetLastFontId()
         {
             var fontId = TexFontUtilities.NoFontId;

--- a/WpfMath/HorizontalRule.cs
+++ b/WpfMath/HorizontalRule.cs
@@ -25,6 +25,13 @@ namespace WpfMath
                 x * scale, (y - this.Height) * scale, this.Width * scale, this.Height * scale));
         }
 
+        public override void RenderGeometry(GeometryGroup geometry, double scale, double x, double y)
+        {
+            RectangleGeometry rectangleGeometry = new RectangleGeometry(new Rect(
+                x * scale, (y - this.Height) * scale, this.Width * scale, this.Height * scale));
+            geometry.Children.Add(rectangleGeometry);
+        }
+
         public override int GetLastFontId()
         {
             return TexFontUtilities.NoFontId;

--- a/WpfMath/OverUnderBox.cs
+++ b/WpfMath/OverUnderBox.cs
@@ -102,6 +102,44 @@ namespace WpfMath
 
         }
 
+        public override void RenderGeometry(GeometryGroup geometry, double scale, double x, double y)
+        {
+            GeometryGroup group = new GeometryGroup();
+            if (this.Over)
+            {
+                // Draw delimeter and script boxes over base box.
+                var centerY = y - this.BaseBox.Height - this.DelimeterBox.Width;
+                var translationX = x + this.DelimeterBox.Width / 2;
+                var translationY = centerY + this.DelimeterBox.Width / 2;
+
+                group.Transform.Value.Translate(translationX * scale, translationY * scale);
+                group.Transform.Value.Rotate(90);
+
+                this.DelimeterBox.RenderGeometry(group, scale, -this.DelimeterBox.Width / 2,
+                    -this.DelimeterBox.Depth + this.DelimeterBox.Width / 2);
+
+                // Draw script box as superscript.
+                if (this.ScriptBox != null)
+                    this.ScriptBox.RenderGeometry(geometry, scale, x, centerY - this.Kern - this.ScriptBox.Depth);
+            }
+            else
+            {
+                // Draw delimeter and script boxes under base box.
+                var centerY = y + this.BaseBox.Depth + this.DelimeterBox.Width;
+                var translationX = x + this.DelimeterBox.Width / 2;
+                var translationY = centerY - this.DelimeterBox.Width / 2;
+
+                group.Transform.Value.Translate(translationX * scale, translationY * scale);
+                group.Transform.Value.Rotate(90);
+                this.DelimeterBox.RenderGeometry(group, scale, -this.DelimeterBox.Width / 2,
+                    -this.DelimeterBox.Depth + this.DelimeterBox.Width / 2);
+
+                // Draw script box as subscript.
+                if (this.ScriptBox != null)
+                    this.ScriptBox.RenderGeometry(geometry, scale, x, centerY + this.Kern + this.ScriptBox.Height);
+            }
+        }
+
         public override int GetLastFontId()
         {
             return TexFontUtilities.NoFontId;

--- a/WpfMath/SVGConverter.cs
+++ b/WpfMath/SVGConverter.cs
@@ -27,9 +27,9 @@ namespace WpfMath
             m_nestedLevel++;
             if (!group.Transform.Value.IsIdentity)
             {
-                svgString.AppendFormat(CultureInfo.InvariantCulture, "<g matrix({0} {1} {2} {3} {4} {5} {6})>"
-                    , group.Transform.Value.M11, group.Transform.Value.M12, group.Transform.Value.OffsetX
-                    , group.Transform.Value.M21, group.Transform.Value.M22, group.Transform.Value.OffsetY);
+                svgString.AppendFormat(CultureInfo.InvariantCulture, "<g transform=\"matrix({0} {1} {2} {3} {4} {5})\">"
+                    , group.Transform.Value.M11, group.Transform.Value.M12
+                    , group.Transform.Value.M21, group.Transform.Value.M22, group.Transform.Value.OffsetX, group.Transform.Value.OffsetY);
             }
             foreach (Geometry geometry in group.Children)
             {

--- a/WpfMath/SVGConverter.cs
+++ b/WpfMath/SVGConverter.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Windows.Media;
+using System.Globalization;
+
+namespace WpfMath
+{
+    public class SVGConverter
+    {
+        private int m_nestedLevel = 0;
+
+        public string ConvertGeometry(Geometry geometry)
+        {
+            StringBuilder svgOutput = new StringBuilder();
+            GeometryGroup group = geometry as GeometryGroup;
+            if (group != null)
+            {
+                AddGeometry(svgOutput, group);
+            }
+            return svgOutput.ToString();
+        }
+
+        private void AddGeometry(StringBuilder svgString, GeometryGroup group)
+        {
+            m_nestedLevel++;
+            if (!group.Transform.Value.IsIdentity)
+            {
+                svgString.AppendFormat(CultureInfo.InvariantCulture, "<g matrix({0} {1} {2} {3} {4} {5} {6})>"
+                    , group.Transform.Value.M11, group.Transform.Value.M12, group.Transform.Value.OffsetX
+                    , group.Transform.Value.M21, group.Transform.Value.M22, group.Transform.Value.OffsetY);
+            }
+            foreach (Geometry geometry in group.Children)
+            {
+                if (geometry is GeometryGroup)
+                {
+                    GeometryGroup childGroup = (GeometryGroup)geometry;
+                    AddGeometry(svgString, childGroup);
+                }
+                else if (geometry is PathGeometry)
+                {
+                    PathGeometry path = (PathGeometry)geometry;
+                    AddGeometry(svgString, path);
+                }
+                else if (geometry is RectangleGeometry)
+                {
+                    RectangleGeometry rectangle = (RectangleGeometry)geometry;
+                    AddGeometry(svgString, rectangle);
+                }
+            }
+            if (!group.Transform.Value.IsIdentity)
+            {
+                svgString.AppendLine("</g>");
+                svgString.AppendLine(Environment.NewLine);
+            }
+
+            m_nestedLevel--;
+        }
+
+        private void AddGeometry(StringBuilder svgString, PathGeometry path)
+        {
+            svgString.Append("<path d=\"");
+            foreach (PathFigure pf in path.Figures)
+            {
+                foreach (PathSegment ps in pf.Segments)
+                {
+                    PolyLineSegment seg = ps as PolyLineSegment;
+                    svgString.Append("M ");
+                    svgString.AppendFormat(CultureInfo.InvariantCulture, "{0} ", seg.Points[0].X);
+                    svgString.AppendFormat(CultureInfo.InvariantCulture, "{0} ", seg.Points[0].Y);
+                    for (int i = 1; i < seg.Points.Count; ++i)
+                    {
+                        svgString.Append("L ");
+                        svgString.AppendFormat(CultureInfo.InvariantCulture, "{0} ", seg.Points[i].X);
+                        svgString.AppendFormat(CultureInfo.InvariantCulture, "{0} ", seg.Points[i].Y);
+                    }
+                    svgString.Append("Z ");
+                }
+            }
+            svgString.Append("\" fill = \"black\" />");
+            svgString.Append(Environment.NewLine);
+        }
+
+        private void AddGeometry(StringBuilder svgString, RectangleGeometry rectangle)
+        {
+            svgString.AppendFormat(CultureInfo.InvariantCulture, "<rect x=\"{0}\" y=\"{1}\" width=\"{2}\" height=\"{3}\" />"
+                , rectangle.Rect.Left, rectangle.Rect.Top, rectangle.Rect.Width, rectangle.Rect.Height);
+            svgString.Append(Environment.NewLine);
+        }
+    }
+}

--- a/WpfMath/TexRenderer.cs
+++ b/WpfMath/TexRenderer.cs
@@ -45,6 +45,13 @@ namespace WpfMath
             }
         }
 
+        public Geometry RenderToGeometry(double x, double y)
+        {
+            GeometryGroup geometry = new GeometryGroup();
+            Box.RenderGeometry(geometry, this.Scale, x / this.Scale, y / this.Scale + this.Box.Height);
+            return geometry;
+        }
+
         public BitmapSource RenderToBitmap(double x, double y)
         {
             var visual = new DrawingVisual();

--- a/WpfMath/VerticalBox.cs
+++ b/WpfMath/VerticalBox.cs
@@ -94,6 +94,17 @@ namespace WpfMath
             }
         }
 
+        public override void RenderGeometry(GeometryGroup geometry, double scale, double x, double y)
+        {
+            var curY = y - Height;
+            foreach (var child in this.Children)
+            {
+                curY += child.Height;
+                child.RenderGeometry(geometry, scale, x + child.Shift - leftMostPos, curY);
+                curY += child.Depth;
+            }
+        }
+
         public override int GetLastFontId()
         {
             var fontId = TexFontUtilities.NoFontId;

--- a/WpfMath/WpfMath.csproj
+++ b/WpfMath/WpfMath.csproj
@@ -99,6 +99,7 @@
     <Compile Include="ScriptsAtom.cs" />
     <Compile Include="SpaceAtom.cs" />
     <Compile Include="StrutBox.cs" />
+    <Compile Include="SVGConverter.cs" />
     <Compile Include="SymbolAtom.cs" />
     <Compile Include="SymbolMappingNotFoundException.cs" />
     <Compile Include="SymbolNotFoundException.cs" />
@@ -145,7 +146,7 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Data\PredefinedColors.xml">
-	  <SubType>Designer</SubType>
+      <SubType>Designer</SubType>
     </EmbeddedResource>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />


### PR DESCRIPTION
Kudos to Marc Palmans!

[Feature: Render geometry & output as SVG](https://bugs.launchpad.net/wpf-math/+bug/1050955)
> I've added code to render to a Geometry and then convert it to an SVG snippet which then can be inserted in an SVG document. At the moment it's hard coded to black with no stroke as I don't need anything else. It should be very easy to add those features if you need them.

## Example:

render in Inkscape
![svg-result](https://cloud.githubusercontent.com/assets/832449/22855343/9dd520e6-f098-11e6-80c1-ca39c6610471.PNG)

[svg-example.zip](https://github.com/ForNeVeR/wpf-math/files/768608/svg-example.zip)

#3 