### PR TITLE
Apply patch Background isn't drawn when using a single char

### DIFF
--- a/WpfMath/CharBox.cs
+++ b/WpfMath/CharBox.cs
@@ -27,6 +27,8 @@ namespace WpfMath
 
         public override void Draw(DrawingContext drawingContext, double scale, double x, double y)
         {
+            base.Draw(drawingContext, scale, x, y);
+
             // Draw character at given position.
             var typeface = this.Character.Font;
             var glyphIndex = typeface.CharacterToGlyphMap[this.Character.Character];


### PR DESCRIPTION
Kudos to Marc Palmans.

[Background isn't drawn when using a single char](https://bugs.launchpad.net/wpf-math/+bug/1046368)
> See title.

## Example:

before patch
![background before](https://cloud.githubusercontent.com/assets/832449/22856880/127dfca4-f0b4-11e6-8a38-474954298d90.PNG)

after patch
![background after](https://cloud.githubusercontent.com/assets/832449/22856882/17295e92-f0b4-11e6-811e-07471e585e30.PNG)

#3 