### PR TITLE
Apply patch Added whitespace and % rendering

### DIFF
--- a/WpfMath/Data/DefaultTexFont.xml
+++ b/WpfMath/Data/DefaultTexFont.xml
@@ -46,6 +46,7 @@ for a text style is not defined (e.g. "numbers" and "small" in "mathcal") -->
 
     <!-- miscellaneous symbols -->
 
+    <SymbolMapping name="%" ch="37" fontId="1"/>
     <SymbolMapping name="comma" ch="59" fontId="0"/>
     <SymbolMapping name="ldotp" ch="58" fontId="0"/>
     <SymbolMapping name="cdotp" ch="162" fontId="3"/>

--- a/WpfMath/Data/PredefinedTexFormulas.xml
+++ b/WpfMath/Data/PredefinedTexFormulas.xml
@@ -1,6 +1,98 @@
 <?xml version='1.0'?>
 
 <PredefinedFormulas enabled="true">
+  
+  <!-- White space and their short form notation -->
+
+  <Formula name="thinspace" enabled="true">
+    <CreateFormula name="f" />
+    <MethodInvocation name="AddStrut" formula="f">
+      <Argument type="Unit" value="Mu" />
+      <Argument type="double" value="3" />
+      <Argument type="double" value="0" />
+      <Argument type="double" value="0" />
+    </MethodInvocation>
+    <Return name="f" />
+  </Formula>
+  <Formula name="," enabled="true">
+    <CreateFormula name="f">
+      <Argument type="string" value="\thinspace" />
+    </CreateFormula>
+    <Return name="f" />
+  </Formula>
+
+  <Formula name="medspace" enabled="true">
+    <CreateFormula name="f" />
+    <MethodInvocation name="AddStrut" formula="f">
+      <Argument type="Unit" value="Mu" />
+      <Argument type="double" value="4" />
+      <Argument type="double" value="0" />
+      <Argument type="double" value="0" />
+    </MethodInvocation>
+    <Return name="f" />
+  </Formula>
+  <Formula name=":" enabled="true">
+    <CreateFormula name="f">
+      <Argument type="string" value="\medspace" />
+    </CreateFormula>
+    <Return name="f" />
+  </Formula>
+
+  <Formula name="thickspace" enabled="true">
+    <CreateFormula name="f" />
+    <MethodInvocation name="AddStrut" formula="f">
+      <Argument type="Unit" value="Mu" />
+      <Argument type="double" value="5" />
+      <Argument type="double" value="0" />
+      <Argument type="double" value="0" />
+    </MethodInvocation>
+    <Return name="f" />
+  </Formula>
+  <Formula name=";" enabled="true">
+    <CreateFormula name="f">
+      <Argument type="string" value="\thickspace" />
+    </CreateFormula>
+    <Return name="f" />
+  </Formula>
+
+  <Formula name="negthinspace" enabled="true">
+    <CreateFormula name="f" />
+    <MethodInvocation name="AddStrut" formula="f">
+      <Argument type="Unit" value="Mu" />
+      <Argument type="double" value="-3" />
+      <Argument type="double" value="0" />
+      <Argument type="double" value="0" />
+    </MethodInvocation>
+    <Return name="f" />
+  </Formula>
+  <Formula name="!" enabled="true">
+    <CreateFormula name="f">
+      <Argument type="string" value="\negthinspace" />
+    </CreateFormula>
+    <Return name="f" />
+  </Formula>
+
+  <Formula name="negmedspace" enabled="true">
+    <CreateFormula name="f" />
+    <MethodInvocation name="AddStrut" formula="f">
+      <Argument type="Unit" value="Mu" />
+      <Argument type="double" value="-4" />
+      <Argument type="double" value="0" />
+      <Argument type="double" value="0" />
+    </MethodInvocation>
+    <Return name="f" />
+  </Formula>
+
+  <Formula name="negthickspace" enabled="true">
+    <CreateFormula name="f" />
+    <MethodInvocation name="AddStrut" formula="f">
+      <Argument type="Unit" value="Mu" />
+      <Argument type="double" value="-5" />
+      <Argument type="double" value="0" />
+      <Argument type="double" value="0" />
+    </MethodInvocation>
+    <Return name="f" />
+  </Formula>
 
   <!-- Composed TeX symbols -->
 

--- a/WpfMath/Data/TexSymbols.xml
+++ b/WpfMath/Data/TexSymbols.xml
@@ -4,6 +4,7 @@
 
   <!-- miscellaneous symbols -->
 
+  <Symbol name="%" type="ord"/>
   <Symbol name="comma" type="punct"/>
   <Symbol name="ldotp" type="punct"/>
   <Symbol name="cdotp" type="punct"/>

--- a/WpfMath/PredefinedTexFormulasParser.cs
+++ b/WpfMath/PredefinedTexFormulasParser.cs
@@ -164,9 +164,17 @@ namespace WpfMath
                 var argTypes = GetArgumentTypes(args);
                 var argValues = GetArgumentValues(this.TempFormulas, args);
 
-                Debug.Assert(argValues.Length == 1);
-                var parser = new TexFormulaParser();
-                var formula = parser.Parse((string)argValues[0]);
+                Debug.Assert(argValues.Length == 1 || argValues.Length == 0);
+                TexFormula formula = null;
+                if (argValues.Length == 1)
+                {
+                    var parser = new TexFormulaParser();
+                    formula = parser.Parse((string)argValues[0]);
+                }
+                else
+                {
+                    formula = new TexFormula();
+                }
 
                 this.TempFormulas.Add(name, formula);
             }

--- a/WpfMath/TexFormulaParser.cs
+++ b/WpfMath/TexFormulaParser.cs
@@ -321,8 +321,9 @@ namespace WpfMath
                 var isEnd = position == value.Length - 1;
                 if (!char.IsLetter(ch) || isEnd)
                 {
-                    // Escape sequence has ended.
-                    if (isEnd)
+                    // Escape sequence has ended
+                    // Or it's a symbol. Assuming in this case it will only be a single char.
+                    if (isEnd || result.Length == 0)
                     {
                         result.Append(ch);
                         position++;

--- a/WpfMath/WpfMath.csproj
+++ b/WpfMath/WpfMath.csproj
@@ -131,7 +131,9 @@
     <Resource Include="Fonts\cmsy10.ttf" />
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="Data\DefaultTexFont.xml" />
+    <EmbeddedResource Include="Data\DefaultTexFont.xml">
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
     <EmbeddedResource Include="Data\GlueSettings.xml" />
     <EmbeddedResource Include="Data\PredefinedTexFormulas.xml">
       <SubType>Designer</SubType>


### PR DESCRIPTION
Kudos to Marc Palmans.

[Added whitespace and % rendering](https://bugs.launchpad.net/wpf-math/+bug/1052891)
> I've added the whitespace commands \thinspace & short form \, and the other variants. I've also added the option to render \%

## Example:
![example](https://cloud.githubusercontent.com/assets/832449/22856998/6f52dd6c-f0b6-11e6-8957-d5d353e558d7.PNG)

#3 