### PR TITLE
Apply patches Image size: Italic support and Incorrect image size when using subscript

### DIFF
--- a/WpfMath/Box.cs
+++ b/WpfMath/Box.cs
@@ -54,6 +54,17 @@ namespace WpfMath
             get { return this.Height + this.Depth; }
         }
 
+        public double TotalWidth
+        {
+            get { return this.Width + this.Italic; }
+        }
+
+        public double Italic
+        {
+            get;
+            set;
+        }
+
         public double Width
         {
             get;
@@ -84,7 +95,7 @@ namespace WpfMath
             {
                 // Fill background of box with color.
                 drawingContext.DrawRectangle(this.Background, null, new Rect(x * scale, (y - Height) * scale,
-                    this.Width * scale, (this.Height + this.Depth) * scale));
+                    (this.Width + this.Italic) * scale, (this.Height + this.Depth) * scale));
             }
         }
 

--- a/WpfMath/CharBox.cs
+++ b/WpfMath/CharBox.cs
@@ -17,6 +17,7 @@ namespace WpfMath
             this.Width = charInfo.Metrics.Width;
             this.Height = charInfo.Metrics.Height;
             this.Depth = charInfo.Metrics.Depth;
+            this.Italic = charInfo.Metrics.Italic;
         }
 
         public CharInfo Character

--- a/WpfMath/HorizontalBox.cs
+++ b/WpfMath/HorizontalBox.cs
@@ -59,6 +59,7 @@ namespace WpfMath
             this.Width = Math.Max(this.Width, childBoxesTotalWidth);
             this.Height = Math.Max((this.Children.Count == 0 ? double.NegativeInfinity : Height), box.Height - box.Shift);
             this.Depth = Math.Max((this.Children.Count == 0 ? double.NegativeInfinity : Depth), box.Depth + box.Shift);
+            this.Italic = Math.Max((this.Children.Count == 0 ? double.NegativeInfinity : Italic), box.Italic);
         }
 
         public override void Draw(DrawingContext drawingContext, double scale, double x, double y)

--- a/WpfMath/ScriptsAtom.cs
+++ b/WpfMath/ScriptsAtom.cs
@@ -152,7 +152,7 @@ namespace WpfMath
             // Check if only subscript is set.
             if (superscriptBox == null)
             {
-                subscriptBox.Shift = Math.Max(Math.Max(shiftDown, texFont.GetSub1(style)), subscriptBox.Height - 4 *
+                subscriptContainerBox.Shift = Math.Max(Math.Max(shiftDown, texFont.GetSub1(style)), subscriptBox.Height - 4 *
                     Math.Abs(texFont.GetXHeight(style, lastFontId)) / 5);
                 resultBox.Add(subscriptContainerBox);
                 return resultBox;

--- a/WpfMath/TexRenderer.cs
+++ b/WpfMath/TexRenderer.cs
@@ -33,7 +33,7 @@ namespace WpfMath
         {
             get
             {
-                return new Size(this.Box.Width * this.Scale, this.Box.TotalHeight * this.Scale);
+                return new Size(this.Box.TotalWidth * this.Scale, this.Box.TotalHeight * this.Scale);
             }
         }
 


### PR DESCRIPTION
Kudos to Marc Palmans!

[Image size: Italic support](https://bugs.launchpad.net/wpf-math/+bug/1046669)
> Image size is incorrectly calculated when using italic.
> I'm not sure if this patch 100% correct but it seems to work for the samples I tested.

[incorrect image size when using subscript](https://bugs.launchpad.net/wpf-math/+bug/1041219)
> The bitmap size is calculated incorrectly when using subscript.

## Example:

a_{b_{c_d}} before
![before patch](https://cloud.githubusercontent.com/assets/832449/22860882/dc01bcae-f123-11e6-9ded-720cda15e03f.png)

a_{b_{c_d}} after
![after patch](https://cloud.githubusercontent.com/assets/832449/22860885/e9984bf8-f123-11e6-818c-b751c68e6ca1.png)

some \\, text \\, P before
![before patch 2](https://cloud.githubusercontent.com/assets/832449/22860886/fd67eabc-f123-11e6-9496-f3cd9ab51811.png)

some \\, text \\, P after
![after patch 2](https://cloud.githubusercontent.com/assets/832449/22860887/05bcccb4-f124-11e6-8c2f-46795d8837d4.png)

#3 