### PR TITLE
Fixes from the old repository

### DIFF
--- a/WpfMath/BigDelimeterAtom.cs
+++ b/WpfMath/BigDelimeterAtom.cs
@@ -8,13 +8,13 @@ namespace WpfMath
     // Atom representing big delimeter (e.g. brackets).
     internal class BigDelimeterAtom : Atom
     {
-        public BigDelimeterAtom(Atom delimeterAtom, int size)
+        public BigDelimeterAtom(SymbolAtom delimeterAtom, int size)
         {
             this.DelimeterAtom = delimeterAtom;
             this.Size = size;
         }
 
-        public Atom DelimeterAtom
+        public SymbolAtom DelimeterAtom
         {
             get;
             private set;

--- a/WpfMath/DefaultTexFont.cs
+++ b/WpfMath/DefaultTexFont.cs
@@ -159,6 +159,8 @@ namespace WpfMath
         public CharInfo GetCharInfo(CharFont charFont, TexStyle style)
         {
             var size = GetSizeFactor(style);
+            if (charFont.Character == '(' || charFont.Character == ')' || charFont.Character == '|')
+                size = 1.8;
             var fontInfo = fontInfoList[charFont.FontId];
             return new CharInfo(charFont.Character, fontInfo.Font, size, charFont.FontId, GetMetrics(charFont, size));
         }

--- a/WpfMath/XmlUtilities.cs
+++ b/WpfMath/XmlUtilities.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Xml.Linq;
@@ -29,7 +30,7 @@ namespace WpfMath
                     return defaultValue.Value;
                 throw new InvalidOperationException();
             }
-            return int.Parse(attribute.Value);
+            return int.Parse(attribute.Value, CultureInfo.InvariantCulture);
         }
 
         public static double AttributeDoubleValue(this XElement element, string attributeName, double? defaultValue = null)
@@ -41,7 +42,7 @@ namespace WpfMath
                     return defaultValue.Value;
                 throw new InvalidOperationException();
             }
-            return double.Parse(attribute.Value);
+            return double.Parse(attribute.Value, CultureInfo.InvariantCulture);
         }
 
         public static string AttributeValue(this XElement element, string attributeName, string defaultValue = null)


### PR DESCRIPTION
These're some commits @alexreg sent me by email. They were initially done in his own clone of the old Launchpad repository. In particular, we know that they should fix [bug #1094269](https://bugs.launchpad.net/wpf-math/+bug/1094269) and [bug #832610](https://bugs.launchpad.net/wpf-math/+bug/832610) but these commits are probably generally useful.