### PR TITLE
Minor fixes

### DIFF
--- a/WpfMath/BigDelimeterAtom.cs
+++ b/WpfMath/BigDelimeterAtom.cs
@@ -8,13 +8,13 @@ namespace WpfMath
     // Atom representing big delimeter (e.g. brackets).
     internal class BigDelimeterAtom : Atom
     {
-        public BigDelimeterAtom(Atom delimeterAtom, int size)
+        public BigDelimeterAtom(SymbolAtom delimeterAtom, int size)
         {
             this.DelimeterAtom = delimeterAtom;
             this.Size = size;
         }
 
-        public Atom DelimeterAtom
+        public SymbolAtom DelimeterAtom
         {
             get;
             private set;

--- a/WpfMath/DefaultTexFont.cs
+++ b/WpfMath/DefaultTexFont.cs
@@ -159,6 +159,8 @@ namespace WpfMath
         public CharInfo GetCharInfo(CharFont charFont, TexStyle style)
         {
             var size = GetSizeFactor(style);
+            if (charFont.Character == '(' || charFont.Character == ')' || charFont.Character == '|')
+                size = 1.8;
             var fontInfo = fontInfoList[charFont.FontId];
             return new CharInfo(charFont.Character, fontInfo.Font, size, charFont.FontId, GetMetrics(charFont, size));
         }


### PR DESCRIPTION
These're changes remaining after rebasing #19. I've checked them out locally, and I don't think I like the new big parens. Please compare yourself:
![image](https://cloud.githubusercontent.com/assets/92793/22870636/a1b69e3a-f1db-11e6-845f-9c4099646c34.png) (old) vs ![image](https://cloud.githubusercontent.com/assets/92793/22870628/955ae1fa-f1db-11e6-907f-900319bd8ce4.png) (new)


I think we should reject the patch and go with #14 instead. @gsomix, what do you think?
