### PR TITLE
Simple delimiter support

### DIFF
--- a/WpfMath.Example/MainWindow.xaml.cs
+++ b/WpfMath.Example/MainWindow.xaml.cs
@@ -122,7 +122,7 @@ namespace WpfMath.Example
 
             var testFormula1 = "\\int_0^{\\infty}{x^{2n} e^{-a x^2} dx} = \\frac{2n-1}{2a} \\int_0^{\\infty}{x^{2(n-1)} e^{-a x^2} dx} = \\frac{(2n-1)!!}{2^{n+1}} \\sqrt{\\frac{\\pi}{a^{2n+1}}}";
             var testFormula2 = "\\int_a^b{f(x) dx} = (b - a) \\sum_{n = 1}^{\\infty}  {\\sum_{m = 1}^{2^n  - 1} { ( { - 1} )^{m + 1} } } 2^{ - n} f(a + m ( {b - a}  )2^{-n} )";
-            var testFormula3 = "L = \\int_a^b \\sqrt[4]{ |\\sum_{i,j=1}^ng_{ij}(\\gamma(t)) (\\frac{d}{dt}x^i\\circ\\gamma(t) ) (\\frac{d}{dt}x^j\\circ\\gamma(t) ) |}dt";
+            var testFormula3 = @"L = \int_a^b \sqrt[4]{ |\sum_{i,j=1}^ng_{ij}\left(\gamma(t)\right) \left[\frac{d}{dt}x^i\circ\gamma(t) \right] \left{\frac{d}{dt}x^j\circ\gamma(t) \right} |}dt";
             this.inputTextBox.Text = testFormula3;
         }
 

--- a/WpfMath.Tests/ParserTests.fs
+++ b/WpfMath.Tests/ParserTests.fs
@@ -7,7 +7,7 @@ open WpfMath
 open WpfMath.Tests.Utils
 
 type ParserTests() =
-    do TexFormulaParser.Initialize()
+    static do TexFormulaParser.Initialize()
 
     let assertParseResult formula expected =
         let parser = TexFormulaParser()

--- a/WpfMath.Tests/ParserTests.fs
+++ b/WpfMath.Tests/ParserTests.fs
@@ -12,10 +12,31 @@ type ParserTests() =
     let assertParseResult formula expected =
         let parser = TexFormulaParser()
         let result = parser.Parse(formula)
-        result.WithDeepEqual(expected).ExposeInternalsOf<TexFormula>().Assert()
+        result.WithDeepEqual(expected)
+            .ExposeInternalsOf<TexFormula>()
+            .ExposeInternalsOf<FencedAtom>()
+            .Assert()
+
+    let ``2+2`` = row [char '2'; symbol "plus"; char '2']
 
     [<Fact>]
     let ``2+2 should be parsed properly`` () =
         assertParseResult
         <| "2+2"
-        <| (formula [char '2'; plus; char '2'])
+        <| formula ``2+2``
+
+    [<Theory>]
+    [<InlineData("(", ")", "lbrack", "rbrack")>]
+    [<InlineData("[", "]", "lsqbrack", "rsqbrack")>]
+    [<InlineData("{", "}", "lbrace", "rbrace")>]
+    [<InlineData("<", ">", "langle", "rangle")>]
+    let ``Delimiters should work`` (left : string, right : string, lResult : string, rResult : string) =
+        assertParseResult
+        <| sprintf @"\left%sa\right%s" left right
+        <| (formula <| fenced (openBrace lResult) (char 'a') (closeBrace rResult))
+
+    [<Fact>]
+    let ``Expression in braces should be parsed`` () =
+        assertParseResult
+        <| @"\left(2+2\right)"
+        <| (formula <| fenced (openBrace "lbrack") ``2+2`` (closeBrace "rbrack"))

--- a/WpfMath.Tests/ParserTests.fs
+++ b/WpfMath.Tests/ParserTests.fs
@@ -40,3 +40,11 @@ type ParserTests() =
         assertParseResult
         <| @"\left(2+2\right)"
         <| (formula <| fenced (openBrace "lbrack") ``2+2`` (closeBrace "rbrack"))
+
+    [<Fact>]
+    let ``Expression after the braces should be parsed`` () =
+        assertParseResult
+        <| @"\left(2+2\right) + 1"
+        <| (formula <| row [ fenced (openBrace "lbrack") ``2+2`` (closeBrace "rbrack")
+                             symbol "plus"
+                             char '1' ])

--- a/WpfMath.Tests/Utils.fs
+++ b/WpfMath.Tests/Utils.fs
@@ -2,10 +2,16 @@
 
 open WpfMath
 
-let formula (atoms : Atom seq) : TexFormula =
-    let root = RowAtom()
-    root.Elements.AddRange(atoms)
+let formula (root : Atom) : TexFormula =
     TexFormula(RootAtom = root)
 
 let char (c : char) : CharAtom = CharAtom(c)
-let plus : SymbolAtom = SymbolAtom("plus", TexAtomType.BinaryOperator, false)
+let symbol (name : string) : SymbolAtom = SymbolAtom(name, TexAtomType.BinaryOperator, false)
+let row (children : Atom seq) : RowAtom =
+    let result = RowAtom()
+    result.Elements.AddRange(children)
+    result
+let fenced left body right : FencedAtom = FencedAtom(body, left, right)
+
+let openBrace (name : string) : SymbolAtom = SymbolAtom(name, TexAtomType.Opening, true)
+let closeBrace (name : string) : SymbolAtom = SymbolAtom(name, TexAtomType.Closing, true)

--- a/WpfMath.sln
+++ b/WpfMath.sln
@@ -11,6 +11,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
 		.gitignore = .gitignore
+		appveyor.yml = appveyor.yml
 		License.md = License.md
 		Readme.md = Readme.md
 		WpfMath.nuspec = WpfMath.nuspec

--- a/WpfMath/Data/PredefinedTexFormulas.xml
+++ b/WpfMath/Data/PredefinedTexFormulas.xml
@@ -244,20 +244,4 @@
     <Return name="f" />
   </Formula>
 
-  <!-- Macros -->
-
-  <Formula name="left" enabled="false">
-    <CreateFormula name="f">
-      <Argument type="string" value="\left" />
-    </CreateFormula>
-    <Return name="f" />
-  </Formula>
-
-  <Formula name="right" enabled="false">
-    <CreateFormula name="f">
-      <Argument type="string" value="\right" />
-    </CreateFormula>
-    <Return name="f" />
-  </Formula>
-
 </PredefinedFormulas>

--- a/WpfMath/DelimiterInfo.cs
+++ b/WpfMath/DelimiterInfo.cs
@@ -1,0 +1,18 @@
+﻿namespace WpfMath
+{
+    /// <summary>
+    /// Information about the body between a pair of delimiters.
+    /// </summary>
+    internal class DelimiterInfo
+    {
+        public Atom Body { get; }
+
+        public SymbolAtom ClosingDelimiter { get; }
+
+        public DelimiterInfo(Atom body, SymbolAtom closingDelimiter)
+        {
+            Body = body;
+            ClosingDelimiter = closingDelimiter;
+        }
+    }
+}

--- a/WpfMath/TexFormulaParser.cs
+++ b/WpfMath/TexFormulaParser.cs
@@ -193,7 +193,8 @@ namespace WpfMath
         private TexFormula Parse(string value, ref int position, bool allowClosingDelimiter)
         {
             var formula = new TexFormula();
-            while (position < value.Length)
+            var closedDelimiter = false;
+            while (position < value.Length && !(allowClosingDelimiter && closedDelimiter))
             {
                 char ch = value[position];
                 if (IsWhiteSpace(ch))
@@ -202,7 +203,7 @@ namespace WpfMath
                 }
                 else if (ch == escapeChar)
                 {
-                    ProcessEscapeSequence(formula, value, ref position, allowClosingDelimiter);
+                    ProcessEscapeSequence(formula, value, ref position, allowClosingDelimiter, ref closedDelimiter);
                 }
                 else if (ch == leftGroupChar)
                 {
@@ -285,7 +286,8 @@ namespace WpfMath
             string value,
             ref int position,
             string command, 
-            bool allowClosingDelimiter)
+            bool allowClosingDelimiter,
+            ref bool closedDelimiter)
         {
             SkipWhiteSpace(value, ref position);
 
@@ -339,6 +341,7 @@ namespace WpfMath
                         if (closing == null)
                             throw new TexParseException($"Cannot find delimiter named {delimiter}");
 
+                        closedDelimiter = true;
                         return closing;
                     }
 
@@ -400,7 +403,8 @@ namespace WpfMath
             TexFormula formula,
             string value,
             ref int position,
-            bool allowClosingDelimiter)
+            bool allowClosingDelimiter,
+            ref bool closedDelimiter)
         {
             var result = new StringBuilder();
             position++;
@@ -472,7 +476,13 @@ namespace WpfMath
                         formula,
                         value,
                         ref position,
-                        ProcessCommand(formula, value, ref position, command, allowClosingDelimiter)));
+                        ProcessCommand(
+                            formula,
+                            value,
+                            ref position, 
+                            command,
+                            allowClosingDelimiter, 
+                            ref closedDelimiter)));
             }
             else
             {

--- a/WpfMath/WpfMath.csproj
+++ b/WpfMath/WpfMath.csproj
@@ -63,6 +63,7 @@
     <Compile Include="CharInfo.cs" />
     <Compile Include="CharSymbol.cs" />
     <Compile Include="BigDelimeterAtom.cs" />
+    <Compile Include="DelimiterInfo.cs" />
     <Compile Include="Extensions.cs" />
     <Compile Include="PredefinedColorParser.cs" />
     <Compile Include="StyledAtom.cs" />


### PR DESCRIPTION
I've added the support for some of the delimiter types mentioned in #14.

Fortunately, it turned out that the render already supports this feature.  Here's the screenshot (check the big braces inside of the sum operator):
![image](https://cloud.githubusercontent.com/assets/92793/23101064/bad2e9b8-f6be-11e6-868e-b8cfed22462a.png)

Remaining issues:

- `\left.` and `\right.` aren't supported (tracked in #14)
- parser is a mess of passed `ref` parameters (tracked in #29)

The implementation is yet very ad-hoc and maybe is missing very much important details; we'll need to determine and fix these later.