### PR TITLE
Operators-symbols should be parsed as BigOp

### DIFF
--- a/src/WpfMath.Tests/ParserTests.fs
+++ b/src/WpfMath.Tests/ParserTests.fs
@@ -119,3 +119,12 @@ type ParserTests() =
                         opWithScripts ``\sin`` null (char 'n') (System.Nullable false);
                         char 'x'
                             ])
+
+    [<Fact>]
+    let ``\int f should be parser properly`` () =
+        assertParseResult
+        <| @"\int f"
+        <| (formula <| row [
+                        op (symbolOp "int") (System.Nullable ())
+                        char 'f'
+                            ])

--- a/src/WpfMath.Tests/Utils.fs
+++ b/src/WpfMath.Tests/Utils.fs
@@ -12,6 +12,7 @@ let opWithScripts (baseAtom : Atom) (subscript : Atom) (superscript : Atom) (use
             : BigOperatorAtom = BigOperatorAtom(baseAtom, subscript, superscript, useVertScripts)
 let group (groupedAtom: Atom) : TypedAtom = TypedAtom(groupedAtom, TexAtomType.Ordinary, TexAtomType.Ordinary)
 let symbol (name : string) : SymbolAtom = SymbolAtom(name, TexAtomType.BinaryOperator, false)
+let symbolOp (name : string) : SymbolAtom = SymbolAtom(name, TexAtomType.BigOperator, false)
 let row (children : Atom seq) : RowAtom =
     let result = RowAtom()
     result.Elements.AddRange(children)

--- a/src/WpfMath/TexFormulaParser.cs
+++ b/src/WpfMath/TexFormulaParser.cs
@@ -436,6 +436,11 @@ namespace WpfMath
                     TexFormula accentFormula = ReadScript(formula, value, ref position);
                     helper.AddAccent(accentFormula, symbolAtom.Name);
                 }
+                else if (symbolAtom.Type == TexAtomType.BigOperator)
+                {
+                    var opAtom = new BigOperatorAtom(symbolAtom, null, null);
+                    formula.Add(AttachScripts(formula, value, ref position, opAtom));
+                }
                 else
                 {
                     formula.Add(AttachScripts(formula, value, ref position, symbolAtom));


### PR DESCRIPTION
Fix #24 

![int](https://cloud.githubusercontent.com/assets/832449/23304793/1dc261ee-fab5-11e6-82a0-c0d3311737c9.PNG)
