### PR TITLE
[Discussion in progress] Round all the calculations to whole pixels

### DIFF
--- a/src/WpfMath/CharBox.cs
+++ b/src/WpfMath/CharBox.cs
@@ -39,6 +39,9 @@ namespace WpfMath
 
         public override void Draw(DrawingContext drawingContext, double scale, double x, double y)
         {
+            x = TexRenderer.RoundToWholePixels(x, scale);
+            y = TexRenderer.RoundToWholePixels(y, scale);
+
             base.Draw(drawingContext, scale, x, y);
 
             GlyphRun glyphRun = GetGlyphRun(scale, x, y);

--- a/src/WpfMath/Controls/FormulaControl.xaml.cs
+++ b/src/WpfMath/Controls/FormulaControl.xaml.cs
@@ -12,7 +12,7 @@ namespace WpfMath.Controls
     public partial class FormulaControl : UserControl
     {
         private static TexFormulaParser formulaParser = new TexFormulaParser();
-        private TexFormula texFormula; 
+        private TexFormula texFormula;
 
         public string Formula
         {
@@ -45,7 +45,7 @@ namespace WpfMath.Controls
         }
 
         public static readonly DependencyProperty FormulaProperty = DependencyProperty.Register(
-            "Formula", typeof(string), typeof(FormulaControl), 
+            "Formula", typeof(string), typeof(FormulaControl),
             new PropertyMetadata("", OnFormulaChanged, CoerceFormula));
 
         public static readonly DependencyProperty ScaleProperty = DependencyProperty.Register(
@@ -84,7 +84,7 @@ namespace WpfMath.Controls
 
             using (var drawingContext = visual.RenderOpen())
             {
-                renderer.Render(drawingContext, 0, 0);
+                renderer.Render(drawingContext);
             }
             formulaContainerElement.Visual = visual;
         }

--- a/src/WpfMath/GlueBox.cs
+++ b/src/WpfMath/GlueBox.cs
@@ -31,6 +31,8 @@ namespace WpfMath
 
         public override void Draw(DrawingContext drawingContext, double scale, double x, double y)
         {
+            x = TexRenderer.RoundToWholePixels(x, scale);
+            y = TexRenderer.RoundToWholePixels(y, scale);
         }
 
         public override int GetLastFontId()

--- a/src/WpfMath/HorizontalBox.cs
+++ b/src/WpfMath/HorizontalBox.cs
@@ -64,6 +64,9 @@ namespace WpfMath
 
         public override void Draw(DrawingContext drawingContext, double scale, double x, double y)
         {
+            x = TexRenderer.RoundToWholePixels(x, scale);
+            y = TexRenderer.RoundToWholePixels(y, scale);
+
             base.Draw(drawingContext, scale, x, y);
 
             var curX = x;

--- a/src/WpfMath/HorizontalRule.cs
+++ b/src/WpfMath/HorizontalRule.cs
@@ -21,6 +21,9 @@ namespace WpfMath
 
         public override void Draw(DrawingContext drawingContext, double scale, double x, double y)
         {
+            x = TexRenderer.RoundToWholePixels(x, scale);
+            y = TexRenderer.RoundToWholePixels(y, scale);
+
             drawingContext.DrawRectangle(this.Foreground ?? Brushes.Black, null, new Rect(
                 x * scale, (y - this.Height) * scale, this.Width * scale, this.Height * scale));
         }

--- a/src/WpfMath/OverUnderBox.cs
+++ b/src/WpfMath/OverUnderBox.cs
@@ -61,6 +61,9 @@ namespace WpfMath
 
         public override void Draw(DrawingContext drawingContext, double scale, double x, double y)
         {
+            x = TexRenderer.RoundToWholePixels(x, scale);
+            y = TexRenderer.RoundToWholePixels(y, scale);
+
             this.BaseBox.Draw(drawingContext, scale, x, y);
 
             if (this.Over)

--- a/src/WpfMath/StrutBox.cs
+++ b/src/WpfMath/StrutBox.cs
@@ -27,6 +27,8 @@ namespace WpfMath
 
         public override void Draw(DrawingContext drawingContext, double scale, double x, double y)
         {
+            x = TexRenderer.RoundToWholePixels(x, scale);
+            y = TexRenderer.RoundToWholePixels(y, scale);
         }
 
         public override int GetLastFontId()

--- a/src/WpfMath/TexRenderer.cs
+++ b/src/WpfMath/TexRenderer.cs
@@ -11,6 +11,12 @@ namespace WpfMath
 {
     public class TexRenderer
     {
+        internal static double RoundToWholePixels(double v, double scale)
+        {
+            var x = Math.Round(v * scale, MidpointRounding.AwayFromZero);
+            return x / scale;
+        }
+
         internal TexRenderer(Box box, double scale)
         {
             this.Box = box;
@@ -68,7 +74,7 @@ namespace WpfMath
 
         public void Render(DrawingContext drawingContext, double x, double y)
         {
-            this.Box.Draw(drawingContext, this.Scale, x / this.Scale, y / this.Scale + this.Box.Height);
+            this.Box.Draw(drawingContext, this.Scale, 0, Box.Height); // x / this.Scale, 0.5 + y / this.Scale + this.Box.Height);
         }
     }
 }

--- a/src/WpfMath/TexRenderer.cs
+++ b/src/WpfMath/TexRenderer.cs
@@ -1,8 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
 using System.Windows;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
@@ -62,7 +58,7 @@ namespace WpfMath
         {
             var visual = new DrawingVisual();
             using (var drawingContext = visual.RenderOpen())
-                this.Render(drawingContext, 0, 0);
+                this.Render(drawingContext);
 
             var width = (int)Math.Ceiling(this.RenderSize.Width);
             var height = (int)Math.Ceiling(this.RenderSize.Height);
@@ -72,9 +68,9 @@ namespace WpfMath
             return bitmap;
         }
 
-        public void Render(DrawingContext drawingContext, double x, double y)
+        public void Render(DrawingContext drawingContext)
         {
-            this.Box.Draw(drawingContext, this.Scale, 0, Box.Height); // x / this.Scale, 0.5 + y / this.Scale + this.Box.Height);
+            this.Box.Draw(drawingContext, this.Scale, 0, Box.Height);
         }
     }
 }

--- a/src/WpfMath/VerticalBox.cs
+++ b/src/WpfMath/VerticalBox.cs
@@ -83,6 +83,9 @@ namespace WpfMath
 
         public override void Draw(DrawingContext drawingContext, double scale, double x, double y)
         {
+            x = TexRenderer.RoundToWholePixels(x, scale);
+            y = TexRenderer.RoundToWholePixels(y, scale);
+
             base.Draw(drawingContext, scale, x, y);
 
             var curY = y - Height;


### PR DESCRIPTION
While investigating #50 I've found that we have small rounding issues everywhere. To fix them, I had to introduce rounding in every `Draw` method.

**Obviously we could add a smarter solution, but let's discuss that in principle at first.**

The outcome is that the formulae are not so blurry. Check out these screenshots:
Before: ![image](https://cloud.githubusercontent.com/assets/92793/23330311/4105d0dc-fb7d-11e6-8e98-c47e87325732.png)

After: ![image](https://cloud.githubusercontent.com/assets/92793/23330313/534d998c-fb7d-11e6-8e3e-6dcc58e9610a.png)

Unfortunately, now we have small troubles _(on some of the scale levels)_ when connecting part of square root tail with the rest of the radical line. Honestly said, earlier we had _small_ issues there, but now we have huge noticeable gap. The following examples were taken with `Scale = 21.0`:

Before:  ![image](https://cloud.githubusercontent.com/assets/92793/23330329/9879f30c-fb7d-11e6-8567-b03f4012266b.png)

After: ![image](https://cloud.githubusercontent.com/assets/92793/23330332/a53b5eaa-fb7d-11e6-83cb-66d6689e78ec.png)

That last issue is cleanly a regression, so I'm not sure if we want to merge this PR as-is. Let's discuss! @torfranz, I welcome you to take a look, too.