### PR TITLE
Fix crash while parsing empty groups

### DIFF
--- a/src/WpfMath.Tests/ParserTests.fs
+++ b/src/WpfMath.Tests/ParserTests.fs
@@ -128,3 +128,9 @@ type ParserTests() =
                         op (symbolOp "int") (System.Nullable ())
                         char 'f'
                             ])
+
+    [<Fact>]
+    let ``{} should be parsed properly`` () =
+        assertParseResult
+        <| @"{}"
+        <| (formula <| group (row []))

--- a/src/WpfMath/TexFormulaParser.cs
+++ b/src/WpfMath/TexFormulaParser.cs
@@ -201,7 +201,8 @@ namespace WpfMath
                 {
                     var groupValue = ReadGroup(formula, value, ref position, leftGroupChar, rightGroupChar);
                     var parsedGroup = Parse(groupValue, textStyle);
-                    var groupAtom = new TypedAtom(parsedGroup.RootAtom, TexAtomType.Ordinary, TexAtomType.Ordinary);
+                    var innerGroupAtom = parsedGroup.RootAtom ?? new RowAtom();
+                    var groupAtom = new TypedAtom(innerGroupAtom, TexAtomType.Ordinary, TexAtomType.Ordinary);
                     formula.Add(AttachScripts(formula, value, ref position, groupAtom));
                 }
                 else if (ch == rightGroupChar)


### PR DESCRIPTION
Example: "{}"
Expected: nothing to render
Actual: crash with NRE