### PR TITLE
Remove delimiter type constraint

### DIFF
--- a/WpfMath.sln
+++ b/WpfMath.sln
@@ -12,9 +12,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.editorconfig = .editorconfig
 		.gitignore = .gitignore
 		appveyor.yml = appveyor.yml
-		License.md = License.md
-		Readme.md = Readme.md
-		ReleaseNotes.md = ReleaseNotes.md
+		LICENSE.md = LICENSE.md
+		README.md = README.md
+		RELEASES.md = RELEASES.md
 		WpfMath.nuspec = WpfMath.nuspec
 	EndProjectSection
 EndProject

--- a/src/WpfMath.Tests/ParserTests.fs
+++ b/src/WpfMath.Tests/ParserTests.fs
@@ -41,6 +41,12 @@ type ParserTests() =
         <| (formula <| fenced (openBrace lResult) (char 'a') (closeBrace rResult))
 
     [<Fact>]
+    let ``Unmatched delimiters should work`` () =
+        assertParseResult
+        <| @"\left)a\right|"
+        <| (formula <| fenced (closeBrace "rbrack") (char 'a') (SymbolAtom("vert", TexAtomType.Ordinary, true)))
+
+    [<Fact>]
     let ``Expression in braces should be parsed`` () =
         assertParseResult
         <| @"\left(2+2\right)"
@@ -73,14 +79,14 @@ type ParserTests() =
         <| (formula <| row [ fenced (openBrace "lbrack") ``\mathrm{2+2}`` (closeBrace "rbrack")
                              symbol "plus"
                              char '1' ])
-    
+
     [<Fact>]
     let ``\mathit should be parsed properly`` () =
         assertParseResult
         <| @"\mathit{sin}"
         <| (formula <| row [styledChar('s', itStyle); styledChar('i', itStyle); styledChar('n', itStyle)])
 
-    
+
     [<Fact>]
     let ``\mathrm should be parsed properly`` () =
         assertParseResult

--- a/src/WpfMath/TexFormulaParser.cs
+++ b/src/WpfMath/TexFormulaParser.cs
@@ -156,7 +156,7 @@ namespace WpfMath
             var bodyRow = embeddedFormula.RootAtom as RowAtom;
             var lastAtom = embeddedFormula.RootAtom as SymbolAtom ?? bodyRow.Elements.LastOrDefault();
             var lastDelimiter = lastAtom as SymbolAtom;
-            if (lastDelimiter == null || !lastDelimiter.IsDelimeter || lastDelimiter.Type != TexAtomType.Closing)
+            if (lastDelimiter == null || !lastDelimiter.IsDelimeter)
                 throw new TexParseException($"Cannot find closing delimiter; got {lastDelimiter} instead");
 
             Atom bodyAtom;
@@ -178,7 +178,7 @@ namespace WpfMath
             {
                 throw new NotSupportedException($"Cannot convert {bodyRow} to fenced atom body");
             }
-            
+
             return new DelimiterInfo(bodyAtom, lastDelimiter);
         }
 
@@ -280,7 +280,7 @@ namespace WpfMath
             TexFormula formula,
             string value,
             ref int position,
-            string command, 
+            string command,
             bool allowClosingDelimiter,
             ref bool closedDelimiter)
         {
@@ -302,11 +302,11 @@ namespace WpfMath
                     return new FractionAtom(numeratorFormula.RootAtom, denominatorFormula.RootAtom, true);
 
                 case "left":
-                    { 
+                    {
                         SkipWhiteSpace(value, ref position);
                         if (position == value.Length)
                             throw new TexParseException("`left` command should be passed a delimiter");
-                    
+
                         var delimiter = value[position];
                         ++position;
 
@@ -321,14 +321,14 @@ namespace WpfMath
                     }
 
                 case "right":
-                    { 
+                    {
                         if (!allowClosingDelimiter)
                             throw new TexParseException("`right` command is not allowed without `left`");
 
                         SkipWhiteSpace(value, ref position);
                         if (position == value.Length)
                             throw new TexParseException("`right` command should be passed a delimiter");
-                    
+
                         var delimiter = value[position];
                         ++position;
 
@@ -426,7 +426,7 @@ namespace WpfMath
             var command = result.ToString();
 
             SymbolAtom symbolAtom = null;
-            TexFormula predefinedFormula = null;            
+            TexFormula predefinedFormula = null;
             if (SymbolAtom.TryGetAtom(command, out symbolAtom))
             {
                 // Symbol was found.
@@ -480,9 +480,9 @@ namespace WpfMath
                         ProcessCommand(
                             formula,
                             value,
-                            ref position, 
+                            ref position,
                             command,
-                            allowClosingDelimiter, 
+                            allowClosingDelimiter,
                             ref closedDelimiter)));
             }
             else


### PR DESCRIPTION
After report by @alexreg in #14 that `|` doesn't work I decided to review the delimiter typing. I've found that things like `\left)` are actually supposed to work, so I removed the constraint on the delimiter type from the closing brace code.

That way, now things like `\left| \frac{2}{2} \right|` work, and even `\left) \frac{2}{2} \right|`.

![image](https://cloud.githubusercontent.com/assets/92793/23337168/6af26992-fc17-11e6-8712-77d7de6dd3a3.png)
