### PR TITLE
Support for empty delimiters

### DIFF
--- a/src/WpfMath.Tests/ParserTests.fs
+++ b/src/WpfMath.Tests/ParserTests.fs
@@ -43,9 +43,10 @@ type ParserTests() =
     [<Theory>]
     [<InlineData(".", ")", true, false)>]
     [<InlineData("(", ".", false, true)>]
-    let ``Empty delimiters should work`` (left : string, right : string, isLeftNull : bool, isRightNull : bool) =
-        let leftBrace = if isLeftNull then null else (openBrace "lbrack")
-        let rightBrace = if isRightNull then null else (closeBrace "rbrack")
+    let ``Empty delimiters should work`` (left : string, right : string, isLeftEmpty : bool, isRightEmpty : bool) =
+        let empty = brace SymbolAtom.EmptyDelimiterName TexAtomType.Ordinary
+        let leftBrace = if isLeftEmpty then empty else (openBrace "lbrack")
+        let rightBrace = if isRightEmpty then empty else (closeBrace "rbrack")
 
         assertParseResult
         <| sprintf @"\left%sa\right%s" left right
@@ -55,7 +56,7 @@ type ParserTests() =
     let ``Unmatched delimiters should work`` () =
         assertParseResult
         <| @"\left)a\right|"
-        <| (formula <| fenced (closeBrace "rbrack") (char 'a') (SymbolAtom("vert", TexAtomType.Ordinary, true)))
+        <| (formula <| fenced (closeBrace "rbrack") (char 'a') (brace "vert" TexAtomType.Ordinary))
 
     [<Fact>]
     let ``Expression in braces should be parsed`` () =

--- a/src/WpfMath.Tests/ParserTests.fs
+++ b/src/WpfMath.Tests/ParserTests.fs
@@ -59,6 +59,11 @@ type ParserTests() =
         <| (formula <| fenced (closeBrace "rbrack") (char 'a') (brace "vert" TexAtomType.Ordinary))
 
     [<Fact>]
+    let ``Non-existing delimiter should throw exception`` () =
+        let markup = @"\left x\right)"
+        Assert.Throws<TexParseException>(fun () -> TexFormulaParser().Parse(markup) |> ignore)
+
+    [<Fact>]
     let ``Expression in braces should be parsed`` () =
         assertParseResult
         <| @"\left(2+2\right)"

--- a/src/WpfMath.Tests/ParserTests.fs
+++ b/src/WpfMath.Tests/ParserTests.fs
@@ -40,6 +40,17 @@ type ParserTests() =
         <| sprintf @"\left%sa\right%s" left right
         <| (formula <| fenced (openBrace lResult) (char 'a') (closeBrace rResult))
 
+    [<Theory>]
+    [<InlineData(".", ")", true, false)>]
+    [<InlineData("(", ".", false, true)>]
+    let ``Empty delimiters should work`` (left : string, right : string, isLeftNull : bool, isRightNull : bool) =
+        let leftBrace = if isLeftNull then null else (openBrace "lbrack")
+        let rightBrace = if isRightNull then null else (closeBrace "rbrack")
+
+        assertParseResult
+        <| sprintf @"\left%sa\right%s" left right
+        <| (formula <| fenced leftBrace (char 'a') rightBrace)
+
     [<Fact>]
     let ``Unmatched delimiters should work`` () =
         assertParseResult

--- a/src/WpfMath.Tests/Utils.fs
+++ b/src/WpfMath.Tests/Utils.fs
@@ -8,7 +8,7 @@ let formula (root : Atom) : TexFormula =
 let char (c : char) : CharAtom = CharAtom(c)
 let styledChar (c : char, style:string) : CharAtom = CharAtom(c, style)
 let op (baseAtom : Atom) (useVertScripts : System.Nullable<bool>)  : BigOperatorAtom = BigOperatorAtom(baseAtom, null, null, useVertScripts)
-let opWithScripts (baseAtom : Atom) (subscript : Atom) (superscript : Atom) (useVertScripts : System.Nullable<bool>) 
+let opWithScripts (baseAtom : Atom) (subscript : Atom) (superscript : Atom) (useVertScripts : System.Nullable<bool>)
             : BigOperatorAtom = BigOperatorAtom(baseAtom, subscript, superscript, useVertScripts)
 let group (groupedAtom: Atom) : TypedAtom = TypedAtom(groupedAtom, TexAtomType.Ordinary, TexAtomType.Ordinary)
 let symbol (name : string) : SymbolAtom = SymbolAtom(name, TexAtomType.BinaryOperator, false)
@@ -19,5 +19,6 @@ let row (children : Atom seq) : RowAtom =
     result
 let fenced left body right : FencedAtom = FencedAtom(body, left, right)
 
-let openBrace (name : string) : SymbolAtom = SymbolAtom(name, TexAtomType.Opening, true)
-let closeBrace (name : string) : SymbolAtom = SymbolAtom(name, TexAtomType.Closing, true)
+let brace (name : string) (braceType : TexAtomType) : SymbolAtom = SymbolAtom(name, braceType, true)
+let openBrace (name : string) : SymbolAtom = brace name TexAtomType.Opening
+let closeBrace (name : string) : SymbolAtom = brace name TexAtomType.Closing

--- a/src/WpfMath/Data/TexFormulaSettings.xml
+++ b/src/WpfMath/Data/TexFormulaSettings.xml
@@ -39,9 +39,10 @@
   <!-- character-to-delimiter-mappings
 
 These are used in the method "embrace(char,char)" from the class "Formula".
-The symbolnames must be defined in "TeXSymbols.xml" as delimiters (del="true")!! -->
+The symbolnames must be defined in "TexSymbols.xml" as delimiters (del="true")!! -->
 
   <CharacterToDelimiterMappings>
+    <Map char="." symbol="_emptyDelimiter"/>
     <Map char="(" symbol="lbrack"/>
     <Map char=")" symbol="rbrack"/>
     <Map char="[" symbol="lsqbrack"/>

--- a/src/WpfMath/Data/TexSymbols.xml
+++ b/src/WpfMath/Data/TexSymbols.xml
@@ -2,6 +2,9 @@
 
 <TeXSymbols>
 
+  <!-- special -->
+  <Symbol name="_emptyDelimiter" type="ord" del="true"/>
+
   <!-- miscellaneous symbols -->
 
   <Symbol name="%" type="ord"/>

--- a/src/WpfMath/FencedAtom.cs
+++ b/src/WpfMath/FencedAtom.cs
@@ -1,7 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace WpfMath
 {
@@ -57,7 +54,7 @@ namespace WpfMath
             var minHeight = Math.Max((delta / 500) * delimeterFactor, 2 * delta - delimeterShortfall);
 
             // Create and add box for left delimeter.
-            if (LeftDelimeter != null)
+            if (LeftDelimeter != null && LeftDelimeter.Name != SymbolAtom.EmptyDelimiterName)
             {
                 var leftDelimeterBox = DelimiterFactory.CreateBox(this.LeftDelimeter.Name, minHeight, environment);
                 CentreBox(leftDelimeterBox, axis);
@@ -76,7 +73,7 @@ namespace WpfMath
                 resultBox.Add(Glue.CreateBox(this.BaseAtom.GetRightType(), TexAtomType.Closing, environment));
 
             // Create and add box for right delimeter.
-            if (this.RightDelimeter != null)
+            if (RightDelimeter != null && RightDelimeter.Name != SymbolAtom.EmptyDelimiterName)
             {
                 var rightDelimeterBox = DelimiterFactory.CreateBox(this.RightDelimeter.Name, minHeight, environment);
                 CentreBox(rightDelimeterBox, axis);

--- a/src/WpfMath/SymbolAtom.cs
+++ b/src/WpfMath/SymbolAtom.cs
@@ -1,14 +1,17 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace WpfMath
 {
     // Atom representing symbol (non-alphanumeric character).
     internal class SymbolAtom : CharSymbol
     {
+        /// <summary>
+        /// Special name of empty delimiter symbol that shouldn't be rendered.
+        /// </summary>
+        internal const string EmptyDelimiterName = "_emptyDelimiter";
+
         // Dictionary of definitions of all symbols, keyed by name.
         private static IDictionary<string, SymbolAtom> symbols;
 
@@ -45,7 +48,7 @@ namespace WpfMath
 
         public static bool TryGetAtom(string name, out SymbolAtom atom)
         {
-            return symbols.TryGetValue(name, out atom);            
+            return symbols.TryGetValue(name, out atom);
         }
 
         public SymbolAtom(SymbolAtom symbolAtom, TexAtomType type)

--- a/src/WpfMath/TexFormulaHelper.cs
+++ b/src/WpfMath/TexFormulaHelper.cs
@@ -64,11 +64,8 @@ namespace WpfMath
 
         public void AddEmbraced(TexFormula formula, string leftSymbol, string rightSymbol)
         {
-            Add(
-                PrepareFencedAtom(
-                    formula?.RootAtom,
-                    TexFormulaParser.GetDelimiterSymbol(leftSymbol),
-                    TexFormulaParser.GetDelimiterSymbol(rightSymbol)));
+            Add(new FencedAtom(formula == null ? null : formula.RootAtom, TexFormulaParser.GetDelimiterSymbol(leftSymbol),
+                TexFormulaParser.GetDelimiterSymbol(rightSymbol)));
         }
 
         public void AddFraction(string numerator, string denominator, bool drawLine)
@@ -306,20 +303,6 @@ namespace WpfMath
             this.Formula.RootAtom = new UnderOverAtom(this.Formula.RootAtom, underFormula == null ?
                 null : underFormula.RootAtom, underUnit, underSpace, underScriptSize, over == null ? null : over.RootAtom,
                 overUnit, overSpace, overScriptSize);
-        }
-
-        internal static FencedAtom PrepareFencedAtom(
-            Atom baseAtom,
-            SymbolAtom leftDelimiter,
-            SymbolAtom rightDelimiter)
-        {
-            if (leftDelimiter.Name == SymbolAtom.EmptyDelimiterName)
-                leftDelimiter = null;
-
-            if (rightDelimiter.Name == SymbolAtom.EmptyDelimiterName)
-                rightDelimiter = null;
-
-            return new FencedAtom(baseAtom, leftDelimiter, rightDelimiter);
         }
     }
 }

--- a/src/WpfMath/TexFormulaHelper.cs
+++ b/src/WpfMath/TexFormulaHelper.cs
@@ -64,8 +64,11 @@ namespace WpfMath
 
         public void AddEmbraced(TexFormula formula, string leftSymbol, string rightSymbol)
         {
-            Add(new FencedAtom(formula == null ? null : formula.RootAtom, TexFormulaParser.GetDelimiterSymbol(leftSymbol),
-                TexFormulaParser.GetDelimiterSymbol(rightSymbol)));
+            Add(
+                PrepareFencedAtom(
+                    formula?.RootAtom,
+                    TexFormulaParser.GetDelimiterSymbol(leftSymbol),
+                    TexFormulaParser.GetDelimiterSymbol(rightSymbol)));
         }
 
         public void AddFraction(string numerator, string denominator, bool drawLine)
@@ -303,6 +306,20 @@ namespace WpfMath
             this.Formula.RootAtom = new UnderOverAtom(this.Formula.RootAtom, underFormula == null ?
                 null : underFormula.RootAtom, underUnit, underSpace, underScriptSize, over == null ? null : over.RootAtom,
                 overUnit, overSpace, overScriptSize);
+        }
+
+        internal static FencedAtom PrepareFencedAtom(
+            Atom baseAtom,
+            SymbolAtom leftDelimiter,
+            SymbolAtom rightDelimiter)
+        {
+            if (leftDelimiter.Name == SymbolAtom.EmptyDelimiterName)
+                leftDelimiter = null;
+
+            if (rightDelimiter.Name == SymbolAtom.EmptyDelimiterName)
+                rightDelimiter = null;
+
+            return new FencedAtom(baseAtom, leftDelimiter, rightDelimiter);
         }
     }
 }

--- a/src/WpfMath/TexFormulaParser.cs
+++ b/src/WpfMath/TexFormulaParser.cs
@@ -154,7 +154,7 @@ namespace WpfMath
                 throw new TexParseException("Cannot find closing delimiter");
 
             var bodyRow = embeddedFormula.RootAtom as RowAtom;
-            var lastAtom = embeddedFormula.RootAtom as SymbolAtom ?? bodyRow.Elements.LastOrDefault();
+            var lastAtom = bodyRow?.Elements.LastOrDefault() ?? embeddedFormula.RootAtom;
             var lastDelimiter = lastAtom as SymbolAtom;
             if (lastDelimiter == null || !lastDelimiter.IsDelimeter)
                 throw new TexParseException($"Cannot find closing delimiter; got {lastDelimiter} instead");
@@ -317,7 +317,7 @@ namespace WpfMath
                             throw new TexParseException($"Cannot find delimiter named {delimiter}");
 
                         var closing = internals.ClosingDelimiter;
-                        return new FencedAtom(internals.Body, opening, closing);
+                        return TexFormulaHelper.PrepareFencedAtom(internals.Body, opening, closing);
                     }
 
                 case "right":

--- a/src/WpfMath/TexFormulaParser.cs
+++ b/src/WpfMath/TexFormulaParser.cs
@@ -120,6 +120,9 @@ namespace WpfMath
 
         internal static SymbolAtom GetDelimiterSymbol(string name)
         {
+            if (name == null)
+                return null;
+
             var result = SymbolAtom.GetAtom(name);
             if (!result.IsDelimeter)
                 return null;

--- a/src/WpfMath/TexFormulaParser.cs
+++ b/src/WpfMath/TexFormulaParser.cs
@@ -317,7 +317,7 @@ namespace WpfMath
                             throw new TexParseException($"Cannot find delimiter named {delimiter}");
 
                         var closing = internals.ClosingDelimiter;
-                        return TexFormulaHelper.PrepareFencedAtom(internals.Body, opening, closing);
+                        return new FencedAtom(internals.Body, opening, closing);
                     }
 
                 case "right":


### PR DESCRIPTION
That's the last piece of #14. It allows to do things like this:

![image](https://cloud.githubusercontent.com/assets/92793/23340116/5a73edd8-fc63-11e6-8ef0-7963c6ad97c3.png)

~~We already support rendering of `FencedAtom` with either `LeftDelimiter` or `RightDelimiter` being defined as `null`, so I've decided that we should construct it so when any delimiter is omitted.~~

~~Although our parser isn't `null`-tolerant at all, and I don't think it should be. So, parser generates symbols with a special names, and those get replaced when constructing the `FencedAtom`.~~

I've used another solution without abusing `null` values.

Closes #14.