### PR TITLE
#66: add information about Knuth license

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ License Notes
 
 The project code is licensed under the terms of [MIT license][license]. The original resourses from [JMathTeX][jmathtex] (`DefaultTexFont.xml`, `GlueSettings.xml`, `PredefinedTexFormulas.xml`, `TexFormulaSettings.xml`, `TexSymbols.xml`) are taken from the [GPLv2-distributed][gpl] [JMathTeX][jmathtex], but JMathTeX authors have granted permission to redistribute these resourses under the MIT license.
 
-The [fonts][] cmex10.ttf, cmmi10.ttf, cmr10.ttf, and cmsy10.ttf and cmtt10.ttf are under [Knuth License][knuth-license].
+The [fonts][] `cmex10.ttf`, `cmmi10.ttf`, `cmr10.ttf`, and `cmsy10.ttf` and `cmtt10.ttf` are under the [Knuth License][knuth-license].
 
 [example]: WpfMath.Example/
 [fonts]: src/WpfMath/Fonts/

--- a/README.md
+++ b/README.md
@@ -28,7 +28,10 @@ License Notes
 
 The project code is licensed under the terms of [MIT license][license]. The original resourses from [JMathTeX][jmathtex] (`DefaultTexFont.xml`, `GlueSettings.xml`, `PredefinedTexFormulas.xml`, `TexFormulaSettings.xml`, `TexSymbols.xml`) are taken from the [GPLv2-distributed][gpl] [JMathTeX][jmathtex], but JMathTeX authors have granted permission to redistribute these resourses under the MIT license.
 
+The [fonts][] cmex10.ttf, cmmi10.ttf, cmr10.ttf, and cmsy10.ttf and cmtt10.ttf are under [Knuth License][knuth-license].
+
 [example]: WpfMath.Example/
+[fonts]: src/WpfMath/Fonts/
 [gpl]: docs/JMathTeX-license.txt
 [license]: LICENSE.md
 
@@ -36,6 +39,7 @@ The project code is licensed under the terms of [MIT license][license]. The orig
 [appveyor]: https://ci.appveyor.com/project/ForNeVeR/wpf-math/branch/master
 [github]: https://github.com/ForNeVeR/wpf-math
 [jmathtex]: http://jmathtex.sourceforge.net/
+[knuth-license]: http://ctan.org/license/knuth
 [launchpad]: https://launchpad.net/wpf-math
 [nuget]: https://www.nuget.org/packages/WpfMath/
 


### PR DESCRIPTION
That's the last missing piece of information about the font licensing.

Closes #66.