### PR TITLE
Use guidelines for WPF render

### DIFF
--- a/src/WpfMath/HorizontalBox.cs
+++ b/src/WpfMath/HorizontalBox.cs
@@ -1,8 +1,4 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Windows;
+﻿using System;
 using System.Windows.Media;
 
 namespace WpfMath
@@ -69,8 +65,17 @@ namespace WpfMath
             var curX = x;
             foreach (var box in this.Children)
             {
+                var guidelines = new GuidelineSet
+                {
+                    GuidelinesX = { curX * scale, (curX + box.TotalWidth) * scale },
+                    GuidelinesY = { (y + box.Shift) * scale, (y + box.TotalHeight) * scale }
+                };
+                drawingContext.PushGuidelineSet(guidelines);
+
                 box.Draw(drawingContext, scale, curX, y + box.Shift);
                 curX += box.Width;
+
+                drawingContext.Pop();
             }
         }
 

--- a/src/WpfMath/VerticalBox.cs
+++ b/src/WpfMath/VerticalBox.cs
@@ -1,8 +1,4 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Windows;
+﻿using System;
 using System.Windows.Media;
 
 namespace WpfMath
@@ -89,8 +85,18 @@ namespace WpfMath
             foreach (var child in this.Children)
             {
                 curY += child.Height;
+
+                var guidelines = new GuidelineSet
+                {
+                    GuidelinesX = { (x + child.Shift - leftMostPos) * scale, x * scale },
+                    GuidelinesY = { curY * scale, (curY + child.Depth) * scale }
+                };
+                drawingContext.PushGuidelineSet(guidelines);
+
                 child.Draw(drawingContext, scale, x + child.Shift - leftMostPos, curY);
                 curY += child.Depth;
+
+                drawingContext.Pop();
             }
         }
 


### PR DESCRIPTION
Fixes #50.

That's my another try to fix that long-standing issue. That time I've finally read the documentation (thanks @Atomosk for pointing me to the tutorial page [Draw lines excactly on physical device pixels](https://wpftutorial.net/DrawOnPhysicalDevicePixels.html)).

That time, we have no obvious regressions for any of the scale settings, so I think that's definitely a way to go. Check the comparison (_clickable_):

![image](https://cloud.githubusercontent.com/assets/92793/23825187/ba2d1fde-06b7-11e7-8ee9-d310196bbe2f.png)

(The fonts are notably clearer now, and even without turning off the font antialiasing settings!)

These changes supersedes the changes in #52 and in the branches `bugfix/50-blur` and `bugfix/50-blur-alternate`; gonna to delete them after the merge.