### PR TITLE
TexRenderer: abstract guidelines from drawing code

### DIFF
--- a/WpfMath.sln
+++ b/WpfMath.sln
@@ -3,9 +3,9 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
 VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WpfMath", "src\WpfMath\WpfMath.csproj", "{010A34F1-1F3E-4528-99B4-95054DD45729}"
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WpfMath.Example", "src\WpfMath.Example\WpfMath.Example.csproj", "{FB56A927-25E4-4EC9-BA36-3A843C606B34}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WpfMath", "src\WpfMath\WpfMath.csproj", "{010A34F1-1F3E-4528-99B4-95054DD45729}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{D9341AA3-BF7C-4CC1-8E11-82258967B82F}"
 	ProjectSection(SolutionItems) = preProject

--- a/src/WpfMath/Box.cs
+++ b/src/WpfMath/Box.cs
@@ -1,8 +1,5 @@
-using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Linq;
-using System.Text;
 using System.Windows;
 using System.Windows.Media;
 
@@ -89,15 +86,26 @@ namespace WpfMath
             set;
         }
 
-        public virtual void Draw(DrawingContext drawingContext, double scale, double x, double y)
+        /// <summary>
+        /// Draws the box into a <see cref="DrawingContext"/> while providing guidelines for WPF render to snap
+        /// the box boundaries onto the device pixel grid.
+        /// </summary>
+        public void DrawWithGuidelines(DrawingContext drawingContext, double scale, double x, double y)
         {
-            if (this.Background != null)
+            var guidelines = new GuidelineSet
             {
-                // Fill background of box with color.
-                drawingContext.DrawRectangle(this.Background, null, new Rect(x * scale, (y - Height) * scale,
-                    (this.Width + this.Italic) * scale, (this.Height + this.Depth) * scale));
-            }
+                GuidelinesX = { scale * x, scale * (x + TotalWidth) },
+                GuidelinesY = { scale * y, scale * (y + TotalHeight) }
+            };
+            drawingContext.PushGuidelineSet(guidelines);
+
+            DrawBackground(drawingContext, scale, x, y);
+            Draw(drawingContext, scale, x, y);
+
+            drawingContext.Pop();
         }
+
+        public abstract void Draw(DrawingContext drawingContext, double scale, double x, double y);
 
         public virtual void RenderGeometry(GeometryGroup geometry, double scale, double x, double y)
         {
@@ -115,5 +123,19 @@ namespace WpfMath
         }
 
         public abstract int GetLastFontId();
+
+        private void DrawBackground(DrawingContext drawingContext, double scale, double x, double y)
+        {
+            if (Background != null)
+            {
+                // Fill background of box with color:
+                drawingContext.DrawRectangle(
+                    Background,
+                    null, 
+                    new Rect(scale * x, scale * (y - Height),
+                    scale * TotalWidth,
+                    scale * TotalHeight));
+            }
+        }
     }
 }

--- a/src/WpfMath/CharBox.cs
+++ b/src/WpfMath/CharBox.cs
@@ -1,8 +1,4 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Windows;
+﻿using System.Windows;
 using System.Windows.Media;
 
 namespace WpfMath
@@ -39,8 +35,6 @@ namespace WpfMath
 
         public override void Draw(DrawingContext drawingContext, double scale, double x, double y)
         {
-            base.Draw(drawingContext, scale, x, y);
-
             GlyphRun glyphRun = GetGlyphRun(scale, x, y);
 
             // Draw character at given position.

--- a/src/WpfMath/HorizontalBox.cs
+++ b/src/WpfMath/HorizontalBox.cs
@@ -60,22 +60,11 @@ namespace WpfMath
 
         public override void Draw(DrawingContext drawingContext, double scale, double x, double y)
         {
-            base.Draw(drawingContext, scale, x, y);
-
             var curX = x;
-            foreach (var box in this.Children)
+            foreach (var box in Children)
             {
-                var guidelines = new GuidelineSet
-                {
-                    GuidelinesX = { curX * scale, (curX + box.TotalWidth) * scale },
-                    GuidelinesY = { (y + box.Shift) * scale, (y + box.TotalHeight) * scale }
-                };
-                drawingContext.PushGuidelineSet(guidelines);
-
-                box.Draw(drawingContext, scale, curX, y + box.Shift);
+                box.DrawWithGuidelines(drawingContext, scale, curX, y + box.Shift);
                 curX += box.Width;
-
-                drawingContext.Pop();
             }
         }
 

--- a/src/WpfMath/OverUnderBox.cs
+++ b/src/WpfMath/OverUnderBox.cs
@@ -1,9 +1,4 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Windows;
-using System.Windows.Media;
+﻿using System.Windows.Media;
 
 namespace WpfMath
 {
@@ -61,7 +56,7 @@ namespace WpfMath
 
         public override void Draw(DrawingContext drawingContext, double scale, double x, double y)
         {
-            this.BaseBox.Draw(drawingContext, scale, x, y);
+            this.BaseBox.DrawWithGuidelines(drawingContext, scale, x, y);
 
             if (this.Over)
             {
@@ -72,14 +67,14 @@ namespace WpfMath
 
                 drawingContext.PushTransform(new TranslateTransform(translationX * scale, translationY * scale));
                 drawingContext.PushTransform(new RotateTransform(90));
-                this.DelimeterBox.Draw(drawingContext, scale, -this.DelimeterBox.Width / 2,
+                this.DelimeterBox.DrawWithGuidelines(drawingContext, scale, -this.DelimeterBox.Width / 2,
                     -this.DelimeterBox.Depth + this.DelimeterBox.Width / 2);
                 drawingContext.Pop();
                 drawingContext.Pop();
 
                 // Draw script box as superscript.
                 if (this.ScriptBox != null)
-                    this.ScriptBox.Draw(drawingContext, scale, x, centerY - this.Kern - this.ScriptBox.Depth);
+                    this.ScriptBox.DrawWithGuidelines(drawingContext, scale, x, centerY - this.Kern - this.ScriptBox.Depth);
             }
             else
             {
@@ -90,14 +85,13 @@ namespace WpfMath
 
                 drawingContext.PushTransform(new TranslateTransform(translationX * scale, translationY * scale));
                 drawingContext.PushTransform(new RotateTransform(90));
-                this.DelimeterBox.Draw(drawingContext, scale, -this.DelimeterBox.Width / 2,
+                this.DelimeterBox.DrawWithGuidelines(drawingContext, scale, -this.DelimeterBox.Width / 2,
                     -this.DelimeterBox.Depth + this.DelimeterBox.Width / 2);
                 drawingContext.Pop();
                 drawingContext.Pop();
 
                 // Draw script box as subscript.
-                if (this.ScriptBox != null)
-                    this.ScriptBox.Draw(drawingContext, scale, x, centerY + this.Kern + this.ScriptBox.Height);
+                ScriptBox?.DrawWithGuidelines(drawingContext, scale, x, centerY + Kern + ScriptBox.Height);
             }
 
         }

--- a/src/WpfMath/TexRenderer.cs
+++ b/src/WpfMath/TexRenderer.cs
@@ -1,8 +1,4 @@
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
+﻿using System;
 using System.Windows;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
@@ -68,7 +64,7 @@ namespace WpfMath
 
         public void Render(DrawingContext drawingContext, double x, double y)
         {
-            this.Box.Draw(drawingContext, this.Scale, x / this.Scale, y / this.Scale + this.Box.Height);
+            Box.DrawWithGuidelines(drawingContext, Scale, x / Scale, y / Scale + Box.Height);
         }
     }
 }

--- a/src/WpfMath/VerticalBox.cs
+++ b/src/WpfMath/VerticalBox.cs
@@ -79,24 +79,13 @@ namespace WpfMath
 
         public override void Draw(DrawingContext drawingContext, double scale, double x, double y)
         {
-            base.Draw(drawingContext, scale, x, y);
-
             var curY = y - Height;
             foreach (var child in this.Children)
             {
                 curY += child.Height;
 
-                var guidelines = new GuidelineSet
-                {
-                    GuidelinesX = { (x + child.Shift - leftMostPos) * scale, x * scale },
-                    GuidelinesY = { curY * scale, (curY + child.Depth) * scale }
-                };
-                drawingContext.PushGuidelineSet(guidelines);
-
-                child.Draw(drawingContext, scale, x + child.Shift - leftMostPos, curY);
+                child.DrawWithGuidelines(drawingContext, scale, x + child.Shift - leftMostPos, curY);
                 curY += child.Depth;
-
-                drawingContext.Pop();
             }
         }
 


### PR DESCRIPTION
That's a follow-up for #71. I've decided to abstract the guidelines code from the `Draw` method, and implement the [Template method pattern](https://en.wikipedia.org/wiki/Template_method_pattern) (with `DrawWithGuidelines` being the template method and `Draw` being the primitive) for the following purposes:

- keep `Draw` clean from the guidelines code
- regain principial compatibility with #69 
- remove the need to call `base.Draw` in `Box`-derived classes

Now every box uses `DrawBackground` method and every box supports guidelines (my previous implementation worked only for `HorizontalBox` and `VerticalBox`).