### PR TITLE
SVG: Added support for curves and removed flattening of the geometry

### DIFF
--- a/src/WpfMath/CharBox.cs
+++ b/src/WpfMath/CharBox.cs
@@ -46,8 +46,7 @@ namespace WpfMath
             GlyphRun glyphRun = GetGlyphRun(scale, x, y);
 
             GeometryGroup geoGroup = glyphRun.BuildGeometry() as GeometryGroup;
-            PathGeometry pg = geoGroup.GetFlattenedPathGeometry();
-            geometry.Children.Add(pg);
+            geometry.Children.Add(geoGroup);
         }
 
         public override int GetLastFontId()


### PR DESCRIPTION
Second attempt.. *grin*
Feel free to criticize & correct.

I'm not a fan of the if(.. is polywhatever) and then .. as polywhatever. constructs (casting twice)
Not sure how to fix it while maintaining readability.

I was also thinking about ditching the entire RenderGeometry thing. It creates more problems than it solves. For example I wanted to include colors in the svg but the geometry only provides path data not colors.

edit: I forgot: currently the geometry returned by BuildGeometry auto converts to cubic bezier curves while truetype fonts has quadratic curves. I've added the case for quadratic curves but it's untested. Should you want to use a more general portable non-wpf (freetype, for example) method of reading/rendering fonts, it's already in there and should work.