### PR TITLE
Fixed a crash when rendering unsupported characters like "Å".

### DIFF
--- a/src/WpfMath.Tests/CharBoxTests.fs
+++ b/src/WpfMath.Tests/CharBoxTests.fs
@@ -8,6 +8,8 @@ open Xunit
 
 open WpfMath
 open WpfMath.Rendering
+open WpfMath.Exceptions
+open System
 
 type CharBoxTests() =
     static do Utils.initializeFontResourceLoading()
@@ -24,3 +26,9 @@ type CharBoxTests() =
         let charBox = CharBox(environment, char)
         charBox.RenderTo(mockedRenderer, x, y)
         Mock.Verify(<@ mockedRenderer.RenderGlyphRun(any(), x, y, Brushes.Black) @>, once)
+
+    [<Fact>]
+    member __.``Currently unsupporteded characters like "Å" should throw TexCharacterMappingNotFoundException``() =
+        let font = DefaultTexFont 20.0
+        let environment = TexEnvironment(TexStyle.Display, font, font)
+        Assert.Throws<TexCharacterMappingNotFoundException>(Func<obj>(fun () -> upcast environment.MathFont.GetDefaultCharInfo('Å', TexStyle.Display)))

--- a/src/WpfMath/TexFontInfo.cs
+++ b/src/WpfMath/TexFontInfo.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Windows.Media;
 using WpfMath.Exceptions;
@@ -141,7 +141,7 @@ namespace WpfMath
 
         public double[] GetMetrics(char character)
         {
-            if (metrics.Length <= character)
+            if (metrics.Length <= character || metrics[character] == null)
             {
                 throw new TexCharacterMappingNotFoundException(
                     $"Cannot determine metrics for '{character}' character in font {FontId}");

--- a/src/WpfMath/TexFontInfo.cs
+++ b/src/WpfMath/TexFontInfo.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Windows.Media;
 using WpfMath.Exceptions;


### PR DESCRIPTION
This fixes a crash when inputting characters or symbols not supported by the font. The issue was discovered using norwegian letters "æ, ø or å".