### PR TITLE
Fixed a crash if inserting a whitespace after a _ or ^ symbol.

### DIFF
--- a/src/WpfMath.Tests/ParserTests.fs
+++ b/src/WpfMath.Tests/ParserTests.fs
@@ -1,4 +1,4 @@
-﻿module WpfMath.Tests.ParserTests
+module WpfMath.Tests.ParserTests
 
 open System
 
@@ -188,3 +188,7 @@ let ``Delimiter with scripts should be parsed properly`` () =
 [<Fact>]
 let ``\sqrt{} should throw a TexParseException``() =
     assertParseThrows<TexParseException> @"\sqrt{}"
+
+[<Fact>]
+let ``"\sum_" should throw a TexParseException``() =
+    assertParseThrows<TexParseException> @"\sum_ "

--- a/src/WpfMath/TexFormulaParser.cs
+++ b/src/WpfMath/TexFormulaParser.cs
@@ -271,10 +271,10 @@ namespace WpfMath
 
         private TexFormula ReadScript(TexFormula formula, string value, ref int position)
         {
+            SkipWhiteSpace(value, ref position);
             if (position == value.Length)
                 throw new TexParseException("illegal end, missing script!");
 
-            SkipWhiteSpace(value, ref position);
             var ch = value[position];
             if (ch == leftGroupChar)
             {


### PR DESCRIPTION
The ReadScript method is checking for position length before potentially incrementing it with SkipWhiteSpace, leading to index out of bounds exception if you insert a whitespace after a _ or ^. Moving SkipWhiteSpace before the length check seems to fix the issue.