### PR TITLE
Fix rendering for stuff like \text{æ,}

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@
 bin/
 obj/
 
+*.DotSettings
 *.user

--- a/src/WpfMath.Tests/BoxTests.fs
+++ b/src/WpfMath.Tests/BoxTests.fs
@@ -7,16 +7,28 @@ open WpfMath
 open WpfMath.Exceptions
 open WpfMath.Tests.Utils
 
+let private parse text =
+    let parser = TexFormulaParser()
+    let result = parser.Parse text
+    result.RootAtom
+
+let private environment =
+    let mathFont = DefaultTexFont 20.0
+    let textFont = TexFormula.GetSystemFont("Arial", 20.0)
+    TexEnvironment(TexStyle.Display, mathFont, textFont)
+
 [<Fact>]
 let ``AccentedAtom should have a skew according to the char``() =
-    let parser = TexFormulaParser()
-    let result = parser.Parse @"\bar{\bar{x}}"
-    let topAtom = result.RootAtom :?> AccentedAtom
+    let topAtom = parse @"\bar{\bar{x}}" :?> AccentedAtom
     let childAtom = topAtom.BaseAtom :?> AccentedAtom
 
-    let font = DefaultTexFont 20.0
-    let environment = TexEnvironment(TexStyle.Display, font, font)
     let topBox = topAtom.CreateBox(environment).Children.[0]
     let childBox = childAtom.CreateBox(environment).Children.[0]
 
     Assert.Equal(topBox.Shift, childBox.Shift)
+
+[<Fact>]
+let ``Box for \text{æ,} should be created successfully``() =
+    let atom = parse @"\text{æ,}"
+    let box = atom.CreateBox(environment)
+    Assert.NotNull(box)

--- a/src/WpfMath.Tests/ParserTests.fs
+++ b/src/WpfMath.Tests/ParserTests.fs
@@ -185,6 +185,11 @@ let ``Delimiter with scripts should be parsed properly`` () =
     <| @"\left(2+2\right)_a^b"
     <| (formula <| scripts (fenced (openBrace "lbrack") ``2+2`` (closeBrace "rbrack")) (char 'a') (char 'b'))
 
+let ``\text doesn't create any SymbolAtoms``() =
+    assertParseResult
+    <| @"\text{2+2}"
+    <| (formula <| row [char '2'; char '+'; char '2'])
+
 [<Fact>]
 let ``\sqrt{} should throw a TexParseException``() =
     assertParseThrows<TexParseException> @"\sqrt{}"

--- a/src/WpfMath/DefaultTexFont.cs
+++ b/src/WpfMath/DefaultTexFont.cs
@@ -50,6 +50,8 @@ namespace WpfMath
             this.Size = size;
         }
 
+        public bool SupportsMetrics => true;
+
         public double Size
         {
             get;

--- a/src/WpfMath/ITeXFont.cs
+++ b/src/WpfMath/ITeXFont.cs
@@ -1,13 +1,11 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
 namespace WpfMath
 {
     // Font that specifies how TexFormula objects are rendered.
     internal interface ITeXFont
     {
+        /// <summary>Whether the font supports <see cref="CharInfo"/>.</summary>
+        bool SupportsMetrics { get; }
+
         double Size { get; }
 
         ITeXFont DeriveFont(double newSize);

--- a/src/WpfMath/RowAtom.cs
+++ b/src/WpfMath/RowAtom.cs
@@ -122,19 +122,22 @@ namespace WpfMath
                     {
                         var font = cs.GetStyledFont(environment);
                         curAtom.IsTextSymbol = true;
-                        var leftAtomCharFont = curAtom.GetCharFont(font);
-                        var rightAtomCharFont = cs.GetCharFont(font);
-                        var ligatureCharFont = font.GetLigature(leftAtomCharFont, rightAtomCharFont);
-                        if (ligatureCharFont == null)
+                        if (font.SupportsMetrics)
                         {
-                            // Atom should be kerned.
-                            kern = font.GetKern(leftAtomCharFont, rightAtomCharFont, environment.Style);
-                        }
-                        else
-                        {
-                            // Atom is part of ligature.
-                            curAtom.SetLigature(new FixedCharAtom(ligatureCharFont));
-                            i++;
+                            var leftAtomCharFont = curAtom.GetCharFont(font);
+                            var rightAtomCharFont = cs.GetCharFont(font);
+                            var ligatureCharFont = font.GetLigature(leftAtomCharFont, rightAtomCharFont);
+                            if (ligatureCharFont == null)
+                            {
+                                // Atom should be kerned.
+                                kern = font.GetKern(leftAtomCharFont, rightAtomCharFont, environment.Style);
+                            }
+                            else
+                            {
+                                // Atom is part of ligature.
+                                curAtom.SetLigature(new FixedCharAtom(ligatureCharFont));
+                                i++;
+                            }
                         }
                     }
                 }

--- a/src/WpfMath/SystemFont.cs
+++ b/src/WpfMath/SystemFont.cs
@@ -15,6 +15,8 @@ namespace WpfMath
             Size = size;
         }
 
+        public bool SupportsMetrics => false;
+
         public double Size { get; }
 
         public ITeXFont DeriveFont(double newSize) => throw MethodNotSupported(nameof(DeriveFont));
@@ -23,7 +25,7 @@ namespace WpfMath
 
         public CharFont GetLigature(CharFont leftChar, CharFont rightChar) => null;
 
-        public CharInfo GetNextLargerCharInfo(CharInfo charInfo, TexStyle style) => 
+        public CharInfo GetNextLargerCharInfo(CharInfo charInfo, TexStyle style) =>
             throw MethodNotSupported(nameof(GetNextLargerCharInfo));
 
         public CharInfo GetDefaultCharInfo(char character, TexStyle style) =>

--- a/src/WpfMath/TexFormula.cs
+++ b/src/WpfMath/TexFormula.cs
@@ -109,7 +109,7 @@ namespace WpfMath
                 return this.RootAtom.CreateBox(environment);
         }
 
-        private SystemFont GetSystemFont(string fontName, double size)
+        internal static SystemFont GetSystemFont(string fontName, double size)
         {
             var fontFamily = Fonts.SystemFontFamilies.First(ff => ff.ToString() == fontName);
             return new SystemFont(size, fontFamily);

--- a/src/WpfMath/TexFormulaParser.cs
+++ b/src/WpfMath/TexFormulaParser.cs
@@ -140,7 +140,7 @@ namespace WpfMath
             return ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r';
         }
 
-        private static bool ShouldSkipWhiteSpace(string style) => style != "text";
+        private static bool ShouldSkipWhiteSpace(string style) => style != TexUtilities.TextStyleName;
 
         public TexFormula Parse(string value, string textStyle = null)
         {
@@ -232,7 +232,7 @@ namespace WpfMath
                         formula,
                         value,
                         ref position,
-                        ConvertCharacter(formula, value, ref position, ch),
+                        ConvertCharacter(formula, ref position, ch),
                         skipWhiteSpace);
                     formula.Add(scriptsAtom);
                 }
@@ -604,15 +604,15 @@ namespace WpfMath
             }
         }
 
-        private Atom ConvertCharacter(TexFormula formula, string value, ref int position, char character)
+        private Atom ConvertCharacter(TexFormula formula, ref int position, char character)
         {
             position++;
-            if (IsSymbol(character))
+            if (IsSymbol(character) && formula.TextStyle != TexUtilities.TextStyleName)
             {
                 // Character is symbol.
                 var symbolName = symbols.ElementAtOrDefault(character);
                 if (string.IsNullOrEmpty(symbolName))
-                    throw new TexParseException("Unknown character : '" + character.ToString() + "'");
+                    throw new TexParseException($"Unknown character : '{character}'");
 
                 try
                 {
@@ -626,9 +626,8 @@ namespace WpfMath
                             + (string)symbolName + "'!", e);
                 }
             }
-            else
+            else // Character is alpha-numeric or should be rendered as text.
             {
-                // Character is alpha-numeric.
                 return new CharAtom(character, formula.TextStyle);
             }
         }


### PR DESCRIPTION
It turned out that the problem lies in the fact that WPF-Math tries to use `SymbolAtom`s in context of `\text` environment. `SymbolAtom` is tied to `TeXFont` and can't be used with `SystemFont`, so I decided to always use `CharAtom`s inside of `\text`.

- makes `CharAtom`s instead of `SymbolAtom`s inside `\text`
- marks `SystemFont` as not supporting the font metrics at the moment (so we won't try to query them in `RowAtom`)
- [x] **TODO**: raise an issue to support metrics (kerning and ligatures) in `SystemFont` → #114
- closes #104

