### PR TITLE
Fix Shift of ScriptsAtom without any scripts

### DIFF
--- a/src/WpfMath.Tests/BoxTests.fs
+++ b/src/WpfMath.Tests/BoxTests.fs
@@ -32,3 +32,15 @@ let ``Box for \text{æ,} should be created successfully``() =
     let atom = parse @"\text{æ,}"
     let box = atom.CreateBox(environment)
     Assert.NotNull(box)
+
+[<Fact>]
+let ``ScriptsAtom should set Shift on the created box when creating box without any sub- or superscript``() =
+    Utils.initializeFontResourceLoading()
+
+    let baseAtom = CharAtom('x')
+    let scriptsAtom = ScriptsAtom(baseAtom, null, null)
+
+    let box = scriptsAtom.CreateBox(environment)
+
+    let expectedShift = -(box.Height + box.Depth) / 2.0 - environment.MathFont.GetAxisHeight(environment.Style)
+    Assert.Equal(expectedShift, box.Shift)

--- a/src/WpfMath/ScriptsAtom.cs
+++ b/src/WpfMath/ScriptsAtom.cs
@@ -1,7 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace WpfMath
 {
@@ -44,7 +41,17 @@ namespace WpfMath
             // Create box for base atom.
             var baseBox = (this.BaseAtom == null ? StrutBox.Empty : this.BaseAtom.CreateBox(environment));
             if (this.SubscriptAtom == null && this.SuperscriptAtom == null)
+            {
+                if (baseBox is CharBox)
+                {
+                    // This situation should only happen when CreateBox called on a temporary ScriptsAtom created from
+                    // BigOperatorAtom.CreateBox. The CharBox's Shift should then be fixed up.
+                    baseBox.Shift = -(baseBox.Height + baseBox.Depth) / 2
+                                    - environment.MathFont.GetAxisHeight(environment.Style);
+                }
+
                 return baseBox;
+            }
 
             // Create result box.
             var resultBox = new HorizontalBox(baseBox);


### PR DESCRIPTION
I've found that `ScriptsAtom` usually returns a shifted `CharAtom` (e.g. a `CharAtom` whose `Shift` is set), but in case when both `SubscriptAtom` and `SuperscriptAtom` are `null`, it returns essentially just a `new CharAtom` without the `Shift`. It causes bugs such as #119. I've decided to make `ScriptsAtom` always return the same kind of `CharAtoms` (i.e. the shifted ones).

Closes #119.