### PR TITLE
Summation two cyrillic symbols (#129)

### DIFF
--- a/src/WpfMath/RowAtom.cs
+++ b/src/WpfMath/RowAtom.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
@@ -114,7 +114,8 @@ namespace WpfMath
 
                 // Check if atom is part of ligature or should be kerned.
                 var kern = 0d;
-                if (hasNextAtom && curAtom.GetRightType() == TexAtomType.Ordinary && curAtom.IsCharSymbol)
+                if ((hasNextAtom && curAtom.GetRightType() == TexAtomType.Ordinary && curAtom.IsCharSymbol) &&
+                    !(this.Elements[i].GetType() == typeof(CharAtom) && ((CharAtom)this.Elements[i]).TextStyle == "text"))
                 {
                     if (nextAtom is CharSymbol cs && ligatureKernChangeSet[(int)nextAtom.GetLeftType()])
                     {


### PR DESCRIPTION
The problem is occurring because even though the Cyrillic symbols are inside "\Text{}", they are considered as SystemFont instead of DefaultTexFont by RowAtom.cs. As a result, the function to GetFontMetrics() inside SystemFont.cs is never called:
Function not called: 
<code>
        private TexFontMetrics GetFontMetrics(char c, Typeface typeface)
        {
            var formattedText = new FormattedText(c.ToString(),
                CultureInfo.CurrentUICulture,
                FlowDirection.LeftToRight,
                typeface,
                1.0,
                Brushes.Black);
            return new TexFontMetrics(formattedText.Width, formattedText.Height, 0.0, formattedText.Width, 1.0);
        }
</code>

By adding the following check inside RowAtom.cs, we check if the Element.TextStyle is actually "text" so we actually use SystemFont.cs for rendering the character. 

References issue: https://github.com/ForNeVeR/wpf-math/issues/129