### PR TITLE
#60 simplified command arguments

### DIFF
--- a/src/WpfMath.Tests/ParserTests.fs
+++ b/src/WpfMath.Tests/ParserTests.fs
@@ -241,3 +241,19 @@ let ``\underline should parse arguments properly``(text : string) : unit =
     assertParseResult
     <| text
     <| (formula (row <| seq { yield upcast underline(char '1'); yield! ``123`` }))
+
+[<Theory>]
+[<InlineData("x^y_z");
+  InlineData("x^y_{z}");
+  InlineData("x^{y}_z");
+  InlineData("x^{y}_{z}");
+  InlineData("{x}^y_z");
+  InlineData("{x}^y_{z}");
+  InlineData("{x}^{y}_z");
+  InlineData("{x}^{y}_{z}");
+  InlineData("x^y_ z");
+  InlineData("{x} ^ {y} _ {z}")>]
+let ``Scripts should be parsed properly``(text : string) : unit =
+    assertParseResult
+    <| text
+    <| (formula <| scripts (char 'x') (char 'z') (char 'y'))

--- a/src/WpfMath.Tests/ParserTests.fs
+++ b/src/WpfMath.Tests/ParserTests.fs
@@ -233,6 +233,16 @@ let ``\sqrt should parse arguments properly``(text : string) : unit =
     <| (formula (row <| seq { yield upcast radical(char '1'); yield! ``123`` }))
 
 [<Theory>]
+[<InlineData(@"\sqrt [2]1123");
+  InlineData(@"\sqrt [ 2]{1}123");
+  InlineData(@"\sqrt[2 ] 1123");
+  InlineData(@"\sqrt[ 2 ] {1}123")>]
+let ``\sqrt should parse optional argument properly``(text : string) : unit =
+    assertParseResult
+    <| text
+    <| (formula (row <| seq { yield upcast radicalWithDegree (char '2') (char '1'); yield! ``123`` }))
+
+[<Theory>]
 [<InlineData(@"\underline1123");
   InlineData(@"\underline{1}123");
   InlineData(@"\underline 1123");

--- a/src/WpfMath.Tests/ParserTests.fs
+++ b/src/WpfMath.Tests/ParserTests.fs
@@ -257,12 +257,8 @@ let ``\underline should parse arguments properly``(text : string) : unit =
   InlineData("x^y_{z}");
   InlineData("x^{y}_z");
   InlineData("x^{y}_{z}");
-  InlineData("{x}^y_z");
-  InlineData("{x}^y_{z}");
-  InlineData("{x}^{y}_z");
-  InlineData("{x}^{y}_{z}");
   InlineData("x^y_ z");
-  InlineData("{x} ^ {y} _ {z}")>]
+  InlineData("x ^ {y} _ {z}")>]
 let ``Scripts should be parsed properly``(text : string) : unit =
     assertParseResult
     <| text

--- a/src/WpfMath.Tests/ParserTests.fs
+++ b/src/WpfMath.Tests/ParserTests.fs
@@ -172,8 +172,8 @@ let ``\text doesn't create any SymbolAtoms``() =
     <| (formula <| row [char '2'; char '+'; char '2'])
 
 [<Fact>]
-let ``\sqrt{} should throw a TexParseException``() =
-    assertParseThrows<TexParseException> @"\sqrt{}"
+let ``\sqrt should throw a TexParseException``() =
+    assertParseThrows<TexParseException> @"\sqrt"
 
 [<Fact>]
 let ``"\sum_ " should throw a TexParseException``() =

--- a/src/WpfMath.Tests/ParserTests.fs
+++ b/src/WpfMath.Tests/ParserTests.fs
@@ -1,5 +1,7 @@
 ﻿module WpfMath.Tests.ParserTests
 
+open System.Windows.Media
+
 open Xunit
 
 open WpfMath
@@ -7,6 +9,7 @@ open WpfMath.Atoms
 open WpfMath.Exceptions
 open WpfMath.Tests.Utils
 
+let private ``123`` : Atom seq = [| char '1'; char '2'; char '3' |] |> Seq.map (fun x -> upcast x)
 let ``2+2`` = row [char '2'; symbol "plus"; char '2']
 let ``\mathrm{2+2}`` = row [styledChar '2' rmStyle; symbol "plus"; styledChar '2' rmStyle]
 let ``\lim`` = row [styledChar 'l' rmStyle; styledChar 'i' rmStyle; styledChar 'm' rmStyle]
@@ -176,3 +179,66 @@ let ``\sqrt{} should throw a TexParseException``() =
 [<Fact>]
 let ``"\sum_ " should throw a TexParseException``() =
     assertParseThrows<TexParseException> @"\sum_ "
+
+[<Theory>]
+[<InlineData(@"\color{red}123");
+  InlineData(@"\color{red}{123}");
+  InlineData(@"\color{red} 123");
+  InlineData(@"\color{red} {123}")>]
+let ``\color should parse arguments properly``(text : string) : unit =
+    assertParseResult
+    <| text
+    <| (formula (row <| seq { yield upcast foreColor ``2+2`` Brushes.Red; yield! ``123`` }))
+
+[<Theory>]
+[<InlineData(@"\colorbox{red}1123");
+  InlineData(@"\colorbox{red}{1}123");
+  InlineData(@"\colorbox{red} 1123");
+  InlineData(@"\colorbox{red} {1}123")>]
+let ``\colorbox should parse arguments properly``(text : string) : unit =
+    assertParseResult
+    <| text
+    <| (formula (row <| seq { yield upcast backColor ``2+2`` Brushes.Red; yield! ``123`` }))
+
+[<Theory>]
+[<InlineData(@"\frac2x123");
+  InlineData(@"\frac2{x}123");
+  InlineData(@"\frac{2}x123");
+  InlineData(@"\frac{2}{x}123");
+  InlineData(@"\frac 2 x123");
+  InlineData(@"\frac2 {x}123");
+  InlineData(@"\frac 2{x}123")>]
+let ``\frac should parse arguments properly``(text : string) : unit =
+    assertParseResult
+    <| text
+    <| (formula (row <| seq { yield upcast fraction (char '2') (char 'x'); yield! ``123`` }))
+
+[<Theory>]
+[<InlineData(@"\overline1123");
+  InlineData(@"\overline{1}123");
+  InlineData(@"\overline 1123");
+  InlineData(@"\overline {1}123")>]
+let ``\overline should parse arguments properly``(text : string) : unit =
+    assertParseResult
+    <| text
+    <| (formula (row <| seq { yield upcast overline(char '1'); yield! ``123`` }))
+
+[<Theory>]
+[<InlineData(@"\sqrt1123");
+  InlineData(@"\sqrt{1}123");
+  InlineData(@"\sqrt 1123");
+  InlineData(@"\sqrt {1}123")>]
+let ``\sqrt should parse arguments properly``(text : string) : unit =
+    assertParseResult
+    <| text
+    <| (formula (row <| seq { yield upcast radical(char '1'); yield! ``123`` }))
+
+[<Theory>]
+[<InlineData(@"\underline1123");
+  InlineData(@"\underline{1}123");
+  InlineData(@"\underline 1123");
+  InlineData(@"\underline {1}123")>]
+let ``\underline should parse arguments properly``(text : string) : unit =
+    assertParseResult
+    <| text
+    <| (formula (row <| seq { yield upcast underline(char '1'); yield! ``123`` }))

--- a/src/WpfMath.Tests/ParserTests.fs
+++ b/src/WpfMath.Tests/ParserTests.fs
@@ -257,3 +257,11 @@ let ``Scripts should be parsed properly``(text : string) : unit =
     assertParseResult
     <| text
     <| (formula <| scripts (char 'x') (char 'z') (char 'y'))
+
+[<Theory>]
+[<InlineData(@"\text 1123");
+  InlineData(@"\text {1}123")>]
+let ``\text command should support extended argument parsing``(text : string) : unit =
+    assertParseResult
+    <| text
+    <| (formula (row <| seq { yield upcast styledChar '1' textStyle; yield! ``123`` }))

--- a/src/WpfMath.Tests/ParserTests.fs
+++ b/src/WpfMath.Tests/ParserTests.fs
@@ -1,7 +1,5 @@
 ﻿module WpfMath.Tests.ParserTests
 
-open System.Windows.Media
-
 open Xunit
 
 open WpfMath
@@ -14,6 +12,7 @@ let ``2+2`` = row [char '2'; symbol "plus"; char '2']
 let ``\mathrm{2+2}`` = row [styledChar '2' rmStyle; symbol "plus"; styledChar '2' rmStyle]
 let ``\lim`` = row [styledChar 'l' rmStyle; styledChar 'i' rmStyle; styledChar 'm' rmStyle]
 let ``\sin`` = row [styledChar 's' rmStyle; styledChar 'i' rmStyle; styledChar 'n' rmStyle]
+let redBrush = brush "#ed1b23"
 
 [<Fact>]
 let ``2+2 should be parsed properly`` () =
@@ -181,14 +180,14 @@ let ``"\sum_ " should throw a TexParseException``() =
     assertParseThrows<TexParseException> @"\sum_ "
 
 [<Theory>]
-[<InlineData(@"\color{red}123");
-  InlineData(@"\color{red}{123}");
-  InlineData(@"\color{red} 123");
-  InlineData(@"\color{red} {123}")>]
+[<InlineData(@"\color{red}1123");
+  InlineData(@"\color{red}{1}123");
+  InlineData(@"\color{red} 1123");
+  InlineData(@"\color{red} {1}123")>]
 let ``\color should parse arguments properly``(text : string) : unit =
     assertParseResult
     <| text
-    <| (formula (row <| seq { yield upcast foreColor ``2+2`` Brushes.Red; yield! ``123`` }))
+    <| (formula (row <| seq { yield upcast foreColor (char '1') redBrush; yield! ``123`` }))
 
 [<Theory>]
 [<InlineData(@"\colorbox{red}1123");
@@ -198,7 +197,7 @@ let ``\color should parse arguments properly``(text : string) : unit =
 let ``\colorbox should parse arguments properly``(text : string) : unit =
     assertParseResult
     <| text
-    <| (formula (row <| seq { yield upcast backColor ``2+2`` Brushes.Red; yield! ``123`` }))
+    <| (formula (row <| seq { yield upcast backColor (char '1') redBrush; yield! ``123`` }))
 
 [<Theory>]
 [<InlineData(@"\frac2x123");

--- a/src/WpfMath.Tests/Utils.fs
+++ b/src/WpfMath.Tests/Utils.fs
@@ -94,3 +94,7 @@ let backColor (body : Atom) (color : Brush) = StyledAtom(null, body, color, null
 let brace (name : string) (braceType : TexAtomType) : SymbolAtom = SymbolAtom(null, name, braceType, true)
 let openBrace (name : string) : SymbolAtom = brace name TexAtomType.Opening
 let closeBrace (name : string) : SymbolAtom = brace name TexAtomType.Closing
+
+let brush : string -> Brush =
+    let converter = BrushConverter()
+    fun color -> downcast converter.ConvertFrom color

--- a/src/WpfMath.Tests/Utils.fs
+++ b/src/WpfMath.Tests/Utils.fs
@@ -80,6 +80,7 @@ let symbol (name : string) : SymbolAtom = symbolSrc name TexAtomType.BinaryOpera
 let symbolOp (name : string) : SymbolAtom = SymbolAtom(null, name, TexAtomType.BigOperator, false)
 let underline(body : Atom) : UnderlinedAtom = UnderlinedAtom(null, body)
 let radical(body : Atom) : Radical = Radical(null, body)
+let radicalWithDegree (degree : Atom) (body : Atom) : Radical = Radical(null, body, degree)
 let row (children : Atom seq) : RowAtom = rowSrc children null
 let fenced left body right : FencedAtom = FencedAtom(null, body, left, right)
 let fraction (num : Atom) (denom : Atom) : FractionAtom = FractionAtom(null, num, denom, true)

--- a/src/WpfMath.Tests/Utils.fs
+++ b/src/WpfMath.Tests/Utils.fs
@@ -2,6 +2,7 @@
 
 open System
 open System.Windows
+open System.Windows.Media
 
 open FSharp.Linq.RuntimeHelpers
 open DeepEqual.Syntax
@@ -77,12 +78,18 @@ let scripts (baseAtom : Atom) (subscript : Atom) (superscript : Atom)
 let group (groupedAtom: Atom) : TypedAtom = TypedAtom(null, groupedAtom, TexAtomType.Ordinary, TexAtomType.Ordinary)
 let symbol (name : string) : SymbolAtom = symbolSrc name TexAtomType.BinaryOperator null
 let symbolOp (name : string) : SymbolAtom = SymbolAtom(null, name, TexAtomType.BigOperator, false)
+let underline(body : Atom) : UnderlinedAtom = UnderlinedAtom(null, body)
+let radical(body : Atom) : Radical = Radical(null, body)
 let row (children : Atom seq) : RowAtom = rowSrc children null
 let fenced left body right : FencedAtom = FencedAtom(null, body, left, right)
+let fraction (num : Atom) (denom : Atom) : FractionAtom = FractionAtom(null, num, denom, true)
 let styledString (style : string) (text : string) : RowAtom =
     text
     |> Seq.map (fun c -> styledChar c style :> Atom)
     |> row
+let overline(body : Atom) : OverlinedAtom = OverlinedAtom(null, body)
+let foreColor (body : Atom) (color : Brush) = StyledAtom(null, body, null, color)
+let backColor (body : Atom) (color : Brush) = StyledAtom(null, body, color, null)
 
 let brace (name : string) (braceType : TexAtomType) : SymbolAtom = SymbolAtom(null, name, braceType, true)
 let openBrace (name : string) : SymbolAtom = brace name TexAtomType.Opening

--- a/src/WpfMath/TexFormulaParser.cs
+++ b/src/WpfMath/TexFormulaParser.cs
@@ -7,6 +7,8 @@ using System.Windows;
 using System.Windows.Media;
 using WpfMath.Atoms;
 using WpfMath.Exceptions;
+using System.Text;
+using System.Text.RegularExpressions;
 
 namespace WpfMath
 {
@@ -274,6 +276,55 @@ namespace WpfMath
             return value.Segment(start, position - start - 1);
         }
 
+        private string ReadGroup(string str,char leftchar,char rightchar,int startPosition)
+        {
+            StringBuilder sb = new StringBuilder();
+            if (startPosition==str.Length)
+            {
+                throw new TexParseException("illegal end!");
+            }
+            int deepness = 0;bool groupfound = false;
+            var start = startPosition;
+            if (str[start]==leftchar)
+            {
+                start++;
+                while (start < str.Length && groupfound == false)
+                {
+                    if (str[start] == leftchar)
+                    {
+                        deepness++;
+                        sb.Append(leftchar);
+                    }
+                    else if (str[start] == rightchar)
+                    {
+                        if (deepness == 0)
+                        {
+                            groupfound = true;
+                        }
+                        else
+                        {
+                            deepness--;
+                            sb.Append(rightchar);
+                        }
+                    }
+                    else
+                    {
+                        sb.Append(str[start]);
+                    }
+                    start++;
+                }
+            }
+
+            if (groupfound)
+            {
+                return sb.ToString();
+            }
+            else
+            {
+                throw new TexParseException("missing->>" + rightchar);
+            }
+        }
+        
         private TexFormula ReadScript(TexFormula formula, SourceSpan value, ref int position)
         {
             SkipWhiteSpace(value, ref position);

--- a/src/WpfMath/TexFormulaParser.cs
+++ b/src/WpfMath/TexFormulaParser.cs
@@ -292,36 +292,8 @@ namespace WpfMath
             return value.Segment(position++, 1);
         }
 
-        private TexFormula ReadScript(TexFormula formula, SourceSpan value, ref int position)
-        {
-            SkipWhiteSpace(value, ref position);
-            if (position == value.Length)
-                throw new TexParseException("illegal end, missing script!");
-
-            var ch = value[position];
-            if (ch == leftGroupChar)
-            {
-                return this.Parse(ReadElement(value, ref position), formula.TextStyle);
-            }
-            else if (ch == escapeChar)
-            {
-                StringBuilder sb = new StringBuilder("\\");
-                position++;
-                while (position < value.Length && IsWhiteSpace(value[position]) == false && value[position] != escapeChar)
-                {
-                    sb.Append(value[position].ToString());
-                    position++;
-                }
-                var scriptlengthb = sb.Length;
-                var scrsrc = value.Segment(position - scriptlengthb, scriptlengthb);
-                return Parse(scrsrc, formula.TextStyle);
-            }
-            else
-            {
-                position++;
-                return Parse(value.Segment(position - 1, 1), formula.TextStyle);
-            }
-        }
+        private TexFormula ReadScript(TexFormula formula, SourceSpan value, ref int position) =>
+            this.Parse(ReadElement(value, ref position), formula.TextStyle);
 
         private Atom ProcessCommand(
             TexFormula formula,
@@ -400,7 +372,7 @@ namespace WpfMath
                         SkipWhiteSpace(value, ref position);
 
                         TexFormula degreeFormula = null;
-                        if (value[position] == leftBracketChar)
+                        if (value.Length > position && value[position] == leftBracketChar)
                         {
                             // Degree of radical is specified.
                             degreeFormula = this.Parse(

--- a/src/WpfMath/TexFormulaParser.cs
+++ b/src/WpfMath/TexFormulaParser.cs
@@ -7,7 +7,6 @@ using System.Windows;
 using System.Windows.Media;
 using WpfMath.Atoms;
 using WpfMath.Exceptions;
-using System.Text;
 
 namespace WpfMath
 {

--- a/src/WpfMath/TexFormulaParser.cs
+++ b/src/WpfMath/TexFormulaParser.cs
@@ -323,6 +323,8 @@ namespace WpfMath
                 case "frac":
                     {
                         // Command is fraction.
+                        if(position== value.Length)
+                            throw new TexParseException("illegal end!");
                         SkipWhiteSpace(value, ref position);
                         if (value[position]==leftGroupChar)
                         {
@@ -379,6 +381,8 @@ namespace WpfMath
                     }
                 case "overline":
                     {
+                       if(position== value.Length)
+                           throw new TexParseException("illegal end!");
                        if (value[position]==leftGroupChar)
                         {
                             var overlineFormula = Parse(ReadGroup(formula, value, ref position, leftGroupChar, rightGroupChar), formula.TextStyle);
@@ -419,6 +423,8 @@ namespace WpfMath
                     {
                         // Command is radical.
                         SkipWhiteSpace(value, ref position);
+                        if(position== value.Length)
+                            throw new TexParseException("illegal end!");
                         if (value[position]==leftBracketChar||value[position]==leftGroupChar)
                         {
                             if (position == value.Length)

--- a/src/WpfMath/TexFormulaParser.cs
+++ b/src/WpfMath/TexFormulaParser.cs
@@ -305,8 +305,6 @@ namespace WpfMath
         {
             int start = position - command.Length;
 
-            SkipWhiteSpace(value, ref position);
-
             SourceSpan source;
             switch (command)
             {
@@ -388,7 +386,6 @@ namespace WpfMath
                 case "underline":
                     {
                         var underlineFormula = this.Parse(ReadElement(value, ref position), formula.TextStyle);
-                        SkipWhiteSpace(value, ref position);
                         source = value.Segment(start, position - start);
                         return new UnderlinedAtom(source, underlineFormula.RootAtom);
                     }

--- a/src/WpfMath/TexFormulaParser.cs
+++ b/src/WpfMath/TexFormulaParser.cs
@@ -209,7 +209,7 @@ namespace WpfMath
                 }
                 else if (ch == leftGroupChar)
                 {
-                    var groupValue = ReadGroup(formula, value, ref position, leftGroupChar, rightGroupChar);
+                    var groupValue = ReadElement(value, ref position);
                     var parsedGroup = Parse(groupValue, textStyle);
                     var innerGroupAtom = parsedGroup.RootAtom ?? new RowAtom(groupValue);
                     var groupAtom = new TypedAtom(
@@ -249,7 +249,7 @@ namespace WpfMath
             return formula;
         }
 
-        private SourceSpan ReadGroup(TexFormula formula, SourceSpan value, ref int position, char openChar, char closeChar)
+        private static SourceSpan ReadElementGroup(SourceSpan value, ref int position, char openChar, char closeChar)
         {
             if (position == value.Length || value[position] != openChar)
                 throw new TexParseException("missing '" + openChar + "'!");
@@ -274,6 +274,23 @@ namespace WpfMath
 
             position++;
             return value.Segment(start, position - start - 1);
+        }
+
+        /// <summary>Reads an element: typically, a curly brace-enclosed value group or a singular value.</summary>
+        /// <exception cref="TexParseException">Will be thrown for ill-formed groups.</exception>
+        private static SourceSpan ReadElement(SourceSpan value, ref int position)
+        {
+            SkipWhiteSpace(value, ref position);
+
+            if (position == value.Length)
+                throw new TexParseException("An element is missing");
+
+            if (value[position] == leftGroupChar)
+            {
+                return ReadElementGroup(value, ref position, leftGroupChar, rightGroupChar);
+            }
+
+            return value.Segment(position++, 1);
         }
 
         private string ReadGroup(string str,char leftchar,char rightchar,int startPosition)
@@ -324,7 +341,7 @@ namespace WpfMath
                 throw new TexParseException("missing->>" + rightchar);
             }
         }
-        
+
         private TexFormula ReadScript(TexFormula formula, SourceSpan value, ref int position)
         {
             SkipWhiteSpace(value, ref position);
@@ -334,7 +351,7 @@ namespace WpfMath
             var ch = value[position];
             if (ch == leftGroupChar)
             {
-                return Parse(ReadGroup(formula, value, ref position, leftGroupChar, rightGroupChar), formula.TextStyle);
+                return this.Parse(ReadElement(value, ref position), formula.TextStyle);
             }
             else if (ch == escapeChar)
             {
@@ -379,11 +396,9 @@ namespace WpfMath
                         SkipWhiteSpace(value, ref position);
                         if (value[position]==leftGroupChar)
                         {
-                            var numeratorFormula = Parse(ReadGroup(formula, value, ref position, leftGroupChar,
-                                                   rightGroupChar), formula.TextStyle);
+                            var numeratorFormula = this.Parse(ReadElement(value, ref position), formula.TextStyle);
                             SkipWhiteSpace(value, ref position);
-                            var denominatorFormula = Parse(ReadGroup(formula, value, ref position, leftGroupChar,
-                                                     rightGroupChar), formula.TextStyle);
+                            var denominatorFormula = this.Parse(ReadElement(value, ref position), formula.TextStyle);
                             if (numeratorFormula.RootAtom == null || denominatorFormula.RootAtom == null)
                                 throw new TexParseException("Both numerator and denominator of a fraction can't be empty!");
 
@@ -424,7 +439,7 @@ namespace WpfMath
                            throw new TexParseException("illegal end!");
                        if (value[position]==leftGroupChar)
                         {
-                            var overlineFormula = Parse(ReadGroup(formula, value, ref position, leftGroupChar, rightGroupChar), formula.TextStyle);
+                            var overlineFormula = this.Parse(ReadElement(value, ref position), formula.TextStyle);
                             SkipWhiteSpace(value, ref position);
                             source = value.Segment(start, position - start);
                             return new OverlinedAtom(source, overlineFormula.RootAtom);
@@ -476,14 +491,13 @@ namespace WpfMath
                             if (value[position] == leftBracketChar)
                             {
                                 // Degree of radical- is specified.
-                                degreeFormula = Parse(ReadGroup(formula, value, ref position, leftBracketChar,
-                                    rightBracketChar), formula.TextStyle);
+                                degreeFormula = this.Parse(
+                                    ReadElementGroup(value, ref position, leftBracketChar, rightBracketChar),
+                                    formula.TextStyle);
                                 SkipWhiteSpace(value, ref position);
                             }
 
-                            var sqrtFormula = this.Parse(
-                                this.ReadGroup(formula, value, ref position, leftGroupChar, rightGroupChar),
-                                formula.TextStyle);
+                            var sqrtFormula = this.Parse(ReadElement(value, ref position), formula.TextStyle);
 
                             if (sqrtFormula.RootAtom == null)
                             {
@@ -503,29 +517,26 @@ namespace WpfMath
 
                 case "underline":
                     {
-                        var underlineFormula = Parse(ReadGroup(formula, value, ref position, leftGroupChar, rightGroupChar), formula.TextStyle);
+                        var underlineFormula = this.Parse(ReadElement(value, ref position), formula.TextStyle);
                         SkipWhiteSpace(value, ref position);
                         source = value.Segment(start, position - start);
                         return new UnderlinedAtom(source, underlineFormula.RootAtom);
                     }
                 case "color":
                     {
-                        var colorName = ReadGroup(formula, value, ref position, leftGroupChar, rightGroupChar);
-                        var remainingString = value.Segment(position);
-                        var remaining = Parse(remainingString, formula.TextStyle);
-                        position = value.Length;
-                        if (predefinedColors.TryGetValue(colorName.ToString(), out var color))
-                        {
-                            source = value.Segment(start, position - start);
-                            return new StyledAtom(source, remaining.RootAtom, null, new SolidColorBrush(color));
-                        }
+                        var colorName = ReadElement(value, ref position);
+                        if (!predefinedColors.TryGetValue(colorName.ToString(), out var color))
+                            throw new TexParseException($"Color {colorName} not found");
 
-                        throw new TexParseException($"Color {colorName} not found");
+                        var bodyValue = ReadElement(value, ref position);
+                        var bodyFormula = this.Parse(bodyValue, formula.TextStyle);
+                        source = value.Segment(start, position - start);
+                        return new StyledAtom(source, bodyFormula.RootAtom, null, new SolidColorBrush(color));
                     }
                 case "colorbox":
                     {
-                        var colorName = ReadGroup(formula, value, ref position, leftGroupChar, rightGroupChar);
-                        var remainingString = ReadGroup(formula, value, ref position, leftGroupChar, rightGroupChar);
+                        var colorName = ReadElement(value, ref position);
+                        var remainingString = ReadElement(value, ref position);
                         var remaining = Parse(remainingString, formula.TextStyle);
                         if (predefinedColors.TryGetValue(colorName.ToString(), out var color))
                         {
@@ -638,8 +649,8 @@ namespace WpfMath
             else if (textStyles.Contains(command))
             {
                 // Text style was found.
-                this.SkipWhiteSpace(value, ref position);
-                var styledFormula = Parse(ReadGroup(formula, value, ref position, leftGroupChar, rightGroupChar), command);
+                SkipWhiteSpace(value, ref position);
+                var styledFormula = this.Parse(ReadElement(value, ref position), command);
                 if (styledFormula.RootAtom == null)
                     throw new TexParseException("Styled text can't be empty!");
                 var atom = this.AttachScripts(formula, value, ref position, styledFormula.RootAtom);
@@ -674,7 +685,7 @@ namespace WpfMath
                 throw new TexParseException("Unknown symbol or command or predefined TeXFormula: '" + command + "'");
             }
         }
-        
+
         private Atom GetSimpleFractionAtom(TexFormula formula,SourceSpan value,ref int position)
         {
             if(value[position]==escapeChar||value [position]=='/')
@@ -701,7 +712,7 @@ namespace WpfMath
                     {
                         throw new TexParseException("Invalid fraction style");
                     }
-                    
+
                 }
                 else if (curChar == " ")
                 {
@@ -723,7 +734,7 @@ namespace WpfMath
 
             if(fracparamsfound==false|| sb.ToString().EndsWith("/"))
                 throw new TexParseException("The current fraction style is invalid");
-            
+
             if (Regex.IsMatch(sb.ToString(), @".+/.+"))
             {
                 midLength = sb.ToString().Split('/')[0].Length;
@@ -742,7 +753,7 @@ namespace WpfMath
                 numeratorFormula = Parse(source.Segment(0, midLength), formula.TextStyle);
                 denominatorFormula = Parse(source.Segment(midLength), formula.TextStyle);
             }
-            
+
             return new FractionAtom(source, numeratorFormula.RootAtom, denominatorFormula.RootAtom, true);
         }
 
@@ -874,7 +885,7 @@ namespace WpfMath
             }
         }
 
-        private void SkipWhiteSpace(SourceSpan value, ref int position)
+        private static void SkipWhiteSpace(SourceSpan value, ref int position)
         {
             while (position < value.Length && IsWhiteSpace(value[position]))
                 position++;


### PR DESCRIPTION
Added the functionality of command arguments being passed without braces. Such as "\infty" in \int_3^\infty, \frac17 and \sqrt\beta.

Closes #60.

TODO (by @ForNeVeR):

- [x] rebase on top of `master`
- [x] add some unit tests
  - [x] one test for each of hardcoded commands (`\frac` etc.)
  - [x] ~~add a test for generic commands (the ones that can be defined in XML)~~ _not applicable_
  - [x] add test for scripts like `_x^y`
  - [x] add test for text style (`\text` or `\mathrm`? See around `textStyles.Contains(command)`)
  - [x] add tests for `\sqrt`'s optional argument (e.g. `\sqrt[2]2`)
- [x] generalize the method (should work for all arguments)