### PR TITLE
Support for measurement arguments.

### DIFF
--- a/src/WpfMath/Converters/SVGConverter.cs
+++ b/src/WpfMath/Converters/SVGConverter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -11,6 +11,8 @@ namespace WpfMath.Converters
     public class SVGConverter
     {
         private int m_nestedLevel = 0;
+
+        public Queue<Brush> GeometryBrushes = new Queue<Brush>();
 
         public string ConvertGeometry(Geometry geometry)
         {
@@ -156,14 +158,22 @@ namespace WpfMath.Converters
                 if (pf.IsClosed)
                     svgString.Append("Z ");
             }
-            svgString.Append("\" fill = \"black\" />");
+
+            SolidColorBrush pathfillBrush = (SolidColorBrush)GeometryBrushes.Dequeue() ?? Brushes.Black;
+
+            string pathfill = "#" + pathfillBrush.Color.ToString().Substring(3) + pathfillBrush.Color.ToString().Substring(1, 2);
+
+            svgString.Append($"\" fill = \"{pathfill}\" />");
             svgString.Append(Environment.NewLine);
         }
 
         private void AddGeometry(StringBuilder svgString, RectangleGeometry rectangle)
         {
-            svgString.AppendFormat(CultureInfo.InvariantCulture, "<rect x=\"{0}\" y=\"{1}\" width=\"{2}\" height=\"{3}\" />"
-                , rectangle.Rect.Left, rectangle.Rect.Top, rectangle.Rect.Width, rectangle.Rect.Height);
+            SolidColorBrush pathfillBrush = (SolidColorBrush)GeometryBrushes.Dequeue() ?? Brushes.Black;
+            string pathfill = "#" + pathfillBrush.Color.ToString().Substring(3) + pathfillBrush.Color.ToString().Substring(1, 2);
+
+            svgString.AppendFormat(CultureInfo.InvariantCulture, "<rect x=\"{0}\" y=\"{1}\" width=\"{2}\" height=\"{3}\" fill=\"{4}\" />"
+                , rectangle.Rect.Left, rectangle.Rect.Top, rectangle.Rect.Width, rectangle.Rect.Height, pathfill);
             svgString.Append(Environment.NewLine);
         }
     }

--- a/src/WpfMath/TexFormulaParser.cs
+++ b/src/WpfMath/TexFormulaParser.cs
@@ -311,7 +311,7 @@ namespace WpfMath
 
             if (value[position]==leftGroupChar)
             {
-                var measurementGroup=ReadArgumentGroup(value, ref position, leftGroupChar, rightGroupChar).ToString().Trim();
+                var measurementGroup=ReadElementGroup(value, ref position, leftGroupChar, rightGroupChar).ToString().Trim();
 
                 if (Regex.IsMatch(measurementGroup, MeasurementPattern))
                 {

--- a/src/WpfMath/TexPredefinedFormulaParser.cs
+++ b/src/WpfMath/TexPredefinedFormulaParser.cs
@@ -173,8 +173,11 @@ namespace WpfMath
                 {
                     formula = new TexFormula();
                 }
-
-                this.TempFormulas.Add(name, formula);
+                if (!this.TempFormulas.ContainsKey(name))
+                {
+                    this.TempFormulas.Add(name, formula);
+                }
+                
             }
         }
 
@@ -194,9 +197,13 @@ namespace WpfMath
             public override void Parse(SourceSpan source, XElement element)
             {
                 var name = element.AttributeValue("name");
-                var result = this.TempFormulas[name];
-                Debug.Assert(result != null);
-                this.Result = result;
+                if (this.TempFormulas.ContainsKey(name))
+                {
+                    var result = this.TempFormulas[name];
+                    Debug.Assert(result != null);
+                    this.Result = result;
+                }
+                
             }
         }
 


### PR DESCRIPTION
This functionality can allow arguments of commands like \raise -0.5em{T} and \kern-2.7 pt J to work, with or without the use of curly braces.