### PR TITLE
Bitmap revolution

### DIFF
--- a/src/WpfMath.Example/MainWindow.xaml.cs
+++ b/src/WpfMath.Example/MainWindow.xaml.cs
@@ -65,7 +65,7 @@ namespace WpfMath.Example
                         break;
 
                     case 2:
-                        var bitmap = renderer.RenderToBitmap(0, 0);
+                        var bitmap = renderer.RenderToBitmap(0, 0, 300);
                         var encoder = new PngBitmapEncoder
                         {
                             Frames = { BitmapFrame.Create(bitmap) }

--- a/src/WpfMath.Tests/TexRendererTests.fs
+++ b/src/WpfMath.Tests/TexRendererTests.fs
@@ -1,0 +1,33 @@
+module WpfMath.Tests.TexRendererTests
+
+open WpfMath
+open Xunit
+
+[<Fact>]
+let ``TexRenderer.RenderToBitmap should create an image of proper size``() =
+    let parser = TexFormulaParser()
+    let formula = parser.Parse "2+2=2"
+    let renderer = formula.GetRenderer(TexStyle.Display, 20.0, "Arial")
+    let bitmap = renderer.RenderToBitmap(0.0, 0.0)
+    Assert.Equal(82, bitmap.PixelWidth)
+    Assert.Equal(17, bitmap.PixelHeight)
+
+[<Fact>]
+let ``TexRenderer.RenderToBitmap should create an image of proper size with offset``() =
+    let parser = TexFormulaParser()
+    let formula = parser.Parse "2+2=2"
+    let renderer = formula.GetRenderer(TexStyle.Display, 20.0, "Arial")
+    let bitmap = renderer.RenderToBitmap(50.0, 50.0)
+    Assert.Equal(132, bitmap.PixelWidth)
+    Assert.Equal(66, bitmap.PixelHeight)
+
+[<Fact>]
+let ``TexRenderer.RenderToBitmap should work with different DPI``() =
+    let parser = TexFormulaParser()
+    let formula = parser.Parse "2+2=2"
+    let renderer = formula.GetRenderer(TexStyle.Display, 20.0, "Arial")
+    let bitmap = renderer.RenderToBitmap(0.0, 0.0, 192.0)
+    Assert.Equal(163, bitmap.PixelWidth)
+    Assert.Equal(34, bitmap.PixelHeight)
+    Assert.Equal(192.0, bitmap.DpiX)
+    Assert.Equal(192.0, bitmap.DpiY)

--- a/src/WpfMath.Tests/WpfMath.Tests.fsproj
+++ b/src/WpfMath.Tests/WpfMath.Tests.fsproj
@@ -36,6 +36,7 @@
     <Compile Include="OverUnderBoxTests.fs" />
     <Compile Include="ParserTests.fs" />
     <Compile Include="SourceDetectionTests.fs" />
+    <Compile Include="TexRendererTests.fs" />
     <Compile Include="TransformationTests.fs" />
     <Compile Include="VerticalBoxTests.fs" />
     <Compile Include="WpfRendererTests.fs" />

--- a/src/WpfMath/TexRenderer.cs
+++ b/src/WpfMath/TexRenderer.cs
@@ -58,10 +58,20 @@ namespace WpfMath
         {
             var visual = new DrawingVisual();
             using (var drawingContext = visual.RenderOpen())
-                this.Render(drawingContext, 0, 0);
+                this.Render(drawingContext, x, y);
+            var bounds = visual.ContentBounds;
+            if (bounds.X < 0 || bounds.Y < 0)
+            {
+                using (var drawingContext = visual.RenderOpen())
+                {
+                    drawingContext.PushTransform(new TranslateTransform(-bounds.X, -bounds.Y));
+                    this.Render(drawingContext, x, y);
+                }
+            }
 
-            var width = (int)Math.Ceiling(this.RenderSize.Width);
-            var height = (int)Math.Ceiling(this.RenderSize.Height);
+            var bounds2 = visual.ContentBounds;
+            var width = (int)Math.Ceiling(bounds2.X + bounds2.Width);
+            var height = (int)Math.Ceiling(bounds2.Y + bounds2.Height);
             var bitmap = new RenderTargetBitmap(width, height, 96, 96, PixelFormats.Default);
             bitmap.Render(visual);
 

--- a/src/WpfMath/TexRenderer.cs
+++ b/src/WpfMath/TexRenderer.cs
@@ -72,19 +72,21 @@ namespace WpfMath
             }
         }
 
-        public BitmapSource RenderToBitmap(double x, double y)
+        public BitmapSource RenderToBitmap(double x, double y, double dpi)
         {
             var visual = new DrawingVisual();
             this.RenderWithPositiveCoordinates(visual, x, y);
 
             var bounds = visual.ContentBounds;
-            var width = (int)Math.Ceiling(bounds.Right);
-            var height = (int)Math.Ceiling(bounds.Bottom);
-            var bitmap = new RenderTargetBitmap(width, height, DefaultDpi, DefaultDpi, PixelFormats.Default);
+            var width = (int)Math.Ceiling(bounds.Right * dpi / DefaultDpi);
+            var height = (int)Math.Ceiling(bounds.Bottom * dpi / DefaultDpi);
+            var bitmap = new RenderTargetBitmap(width, height, dpi, dpi, PixelFormats.Default);
             bitmap.Render(visual);
 
             return bitmap;
         }
+
+        public BitmapSource RenderToBitmap(double x, double y) => this.RenderToBitmap(x, y, DefaultDpi);
 
         public void Render(DrawingContext drawingContext, double x, double y) =>
             RenderFormulaTo(new WpfElementRenderer(drawingContext, Scale), x, y);

--- a/src/WpfMath/TexRenderer.cs
+++ b/src/WpfMath/TexRenderer.cs
@@ -67,7 +67,8 @@ namespace WpfMath
 
             using (var drawingContext = visual.RenderOpen())
             {
-                drawingContext.PushTransform(new TranslateTransform(-bounds.X, -bounds.Y));
+                drawingContext.PushTransform(
+                    new TranslateTransform(Math.Max(0.0, -bounds.X), Math.Max(0.0, -bounds.Y)));
                 this.Render(drawingContext, x, y);
             }
         }


### PR DESCRIPTION
Closes #168.

I've added an additional method to render a bitmap with DPI (while keeping an old overload for binary compatibility), and fixed a couple of bugs noted in #168.

**Note for review:** please make sure to disable whitespace comparison. I've converted the line endings to `\n` (the standard we use) in a couple of files.

_This happens automatically whenever I commit anything and I think that's a good thing and we don't need to bother about it._