### PR TITLE
Fixed a crash due to Atom source being null when reading source length.

### DIFF
--- a/src/WpfMath/TexFormulaParser.cs
+++ b/src/WpfMath/TexFormulaParser.cs
@@ -216,7 +216,7 @@ namespace WpfMath
                         TexAtomType.Ordinary,
                         TexAtomType.Ordinary);
                     var scriptsAtom = this.AttachScripts(formula, value, ref position, groupAtom);
-                    formula.Add(scriptsAtom, value.Segment(initialPosition, scriptsAtom.Source.Length));
+                    formula.Add(scriptsAtom, value.Segment(initialPosition, position - initialPosition));
                 }
                 else if (ch == rightGroupChar)
                 {


### PR DESCRIPTION
In certain situations, the Source of scriptsAtom is null, like on {\hat T}. This causes the nullreference exception. I'm not clear on wheter it's supposed to be able to null or not, but i believe "position - initialPosition" should always be equal to the source length anyway.