### PR TITLE
Fix \lbrack and \rbrack

### DIFF
--- a/src/WpfMath.Tests/ParserTests.fs
+++ b/src/WpfMath.Tests/ParserTests.fs
@@ -21,8 +21,8 @@ let ``2+2 should be parsed properly`` () =
     <| formula ``2+2``
 
 [<Theory>]
-[<InlineData("(", ")", "lbrack", "rbrack")>]
-[<InlineData("[", "]", "lsqbrack", "rsqbrack")>]
+[<InlineData("(", ")", "(", ")")>]
+[<InlineData("[", "]", "lbrack", "rbrack")>]
 [<InlineData("{", "}", "lbrace", "rbrace")>]
 [<InlineData("<", ">", "langle", "rangle")>]
 let ``Delimiters should work`` (left : string, right : string, lResult : string, rResult : string) =
@@ -35,8 +35,8 @@ let ``Delimiters should work`` (left : string, right : string, lResult : string,
 [<InlineData("(", ".", false, true)>]
 let ``Empty delimiters should work`` (left : string, right : string, isLeftEmpty : bool, isRightEmpty : bool) =
     let empty = brace SymbolAtom.EmptyDelimiterName TexAtomType.Ordinary
-    let leftBrace = if isLeftEmpty then empty else (openBrace "lbrack")
-    let rightBrace = if isRightEmpty then empty else (closeBrace "rbrack")
+    let leftBrace = if isLeftEmpty then empty else (openBrace "(")
+    let rightBrace = if isRightEmpty then empty else (closeBrace ")")
 
     assertParseResult
     <| sprintf @"\left%sa\right%s" left right
@@ -46,7 +46,7 @@ let ``Empty delimiters should work`` (left : string, right : string, isLeftEmpty
 let ``Unmatched delimiters should work`` () =
     assertParseResult
     <| @"\left)a\right|"
-    <| (formula <| fenced (closeBrace "rbrack") (char 'a') (brace "vert" TexAtomType.Ordinary))
+    <| (formula <| fenced (closeBrace ")") (char 'a') (brace "vert" TexAtomType.Ordinary))
 
 [<Fact>]
 let ``Non-existing delimiter should throw exception`` () =
@@ -57,13 +57,13 @@ let ``Non-existing delimiter should throw exception`` () =
 let ``Expression in braces should be parsed`` () =
     assertParseResult
     <| @"\left(2+2\right)"
-    <| (formula <| fenced (openBrace "lbrack") ``2+2`` (closeBrace "rbrack"))
+    <| (formula <| fenced (openBrace "(") ``2+2`` (closeBrace ")"))
 
 [<Fact>]
 let ``Expression after the braces should be parsed`` () =
     assertParseResult
     <| @"\left(2+2\right) + 1"
-    <| (formula <| row [ fenced (openBrace "lbrack") ``2+2`` (closeBrace "rbrack")
+    <| (formula <| row [ fenced (openBrace "(") ``2+2`` (closeBrace ")")
                          symbol "plus"
                          char '1' ])
 
@@ -95,7 +95,7 @@ let ``\mathrm should be parsed properly`` () =
 let ``\mathrm should be parsed properly for complex eqs`` () =
     assertParseResult
     <| @"\mathrm{\left(2+2\right)} + 1"
-    <| (formula <| row [ fenced (openBrace "lbrack") ``\mathrm{2+2}`` (closeBrace "rbrack")
+    <| (formula <| row [ fenced (openBrace "(") ``\mathrm{2+2}`` (closeBrace ")")
                          symbol "plus"
                          char '1' ])
 
@@ -164,7 +164,7 @@ let ``{} should be parsed properly`` () =
 let ``Delimiter with scripts should be parsed properly`` () =
     assertParseResult
     <| @"\left(2+2\right)_a^b"
-    <| (formula <| scripts (fenced (openBrace "lbrack") ``2+2`` (closeBrace "rbrack")) (char 'a') (char 'b'))
+    <| (formula <| scripts (fenced (openBrace "(") ``2+2`` (closeBrace ")")) (char 'a') (char 'b'))
 
 let ``\text doesn't create any SymbolAtoms``() =
     assertParseResult

--- a/src/WpfMath/Data/DefaultTexFont.xml
+++ b/src/WpfMath/Data/DefaultTexFont.xml
@@ -114,8 +114,10 @@ for a text style is not defined (e.g. "numbers" and "small" in "mathcal") -->
 
     <SymbolMapping name="lbrace" ch="102" fontId="3"/>
     <SymbolMapping name="rbrace" ch="103" fontId="3"/>
-    <SymbolMapping name="lbrack" ch="40" fontId="1"/>
-    <SymbolMapping name="rbrack" ch="41" fontId="1"/>
+    <SymbolMapping name="(" ch="40" fontId="1"/>
+    <SymbolMapping name=")" ch="41" fontId="1"/>
+    <SymbolMapping name="lbrack" ch="91" fontId="1"/>
+    <SymbolMapping name="rbrack" ch="93" fontId="1"/>
     <SymbolMapping name="rsqbrack" ch="93" fontId="1"/>
     <SymbolMapping name="lsqbrack" ch="91" fontId="1"/>
     <SymbolMapping name="langle" ch="104" fontId="3"/>

--- a/src/WpfMath/Data/DefaultTexFont.xml
+++ b/src/WpfMath/Data/DefaultTexFont.xml
@@ -118,8 +118,6 @@ for a text style is not defined (e.g. "numbers" and "small" in "mathcal") -->
     <SymbolMapping name=")" ch="41" fontId="1"/>
     <SymbolMapping name="lbrack" ch="91" fontId="1"/>
     <SymbolMapping name="rbrack" ch="93" fontId="1"/>
-    <SymbolMapping name="rsqbrack" ch="93" fontId="1"/>
-    <SymbolMapping name="lsqbrack" ch="91" fontId="1"/>
     <SymbolMapping name="langle" ch="104" fontId="3"/>
     <SymbolMapping name="rangle" ch="105" fontId="3"/>
     <SymbolMapping name="lfloor" ch="98" fontId="3"/>

--- a/src/WpfMath/Data/TexFormulaSettings.xml
+++ b/src/WpfMath/Data/TexFormulaSettings.xml
@@ -49,13 +49,13 @@
     <Map char="-" symbol="minus"/>
     <Map char="/" symbol="slash"/>
     <Map char="*" symbol="ast"/>
-    <Map char="(" symbol="lbrack"/>
+    <Map char="(" symbol="("/>
     <Map char="." symbol="normaldot"/>
     <Map char=";" symbol="semicolon"/>
     <Map char="&gt;" symbol="gt"/>
     <Map char="{" symbol="lbrace"/>
     <Map char="!" symbol="faculty"/>
-    <Map char=")" symbol="rbrack"/>
+    <Map char=")" symbol=")"/>
     <Map char="," symbol="comma"/>
     <Map char="&lt;" symbol="lt"/>
     <Map char="?" symbol="question"/>
@@ -74,8 +74,8 @@ The symbolnames must be defined in "TexSymbols.xml" as delimiters (del="true")!!
 
   <CharacterToDelimiterMappings>
     <Map char="." symbol="_emptyDelimiter"/>
-    <Map char="(" symbol="lbrack"/>
-    <Map char=")" symbol="rbrack"/>
+    <Map char="(" symbol="("/>
+    <Map char=")" symbol=")"/>
     <Map char="[" symbol="lsqbrack"/>
     <Map char="]" symbol="rsqbrack"/>
     <Map char="{" symbol="lbrace"/>

--- a/src/WpfMath/Data/TexFormulaSettings.xml
+++ b/src/WpfMath/Data/TexFormulaSettings.xml
@@ -59,11 +59,11 @@
     <Map char="," symbol="comma"/>
     <Map char="&lt;" symbol="lt"/>
     <Map char="?" symbol="question"/>
-    <Map char="]" symbol="rsqbrack"/>
+    <Map char="]" symbol="rbrack"/>
     <Map char="|" symbol="vert"/>
     <Map char=":" symbol="colon"/>
     <Map char="=" symbol="equals"/>
-    <Map char="[" symbol="lsqbrack"/>
+    <Map char="[" symbol="lbrack"/>
     <Map char="}" symbol="rbrace"/>
   </CharacterToSymbolMappings>
 
@@ -76,8 +76,8 @@ The symbolnames must be defined in "TexSymbols.xml" as delimiters (del="true")!!
     <Map char="." symbol="_emptyDelimiter"/>
     <Map char="(" symbol="("/>
     <Map char=")" symbol=")"/>
-    <Map char="[" symbol="lsqbrack"/>
-    <Map char="]" symbol="rsqbrack"/>
+    <Map char="[" symbol="lbrack"/>
+    <Map char="]" symbol="rbrack"/>
     <Map char="{" symbol="lbrace"/>
     <Map char="}" symbol="rbrace"/>
     <Map char="&lt;" symbol="langle"/>

--- a/src/WpfMath/Data/TexSymbols.xml
+++ b/src/WpfMath/Data/TexSymbols.xml
@@ -70,8 +70,6 @@
   <Symbol name="rbrace" type="close" del="true"/>
   <Symbol name="lbrack" type="open" del="true"/>
   <Symbol name="rbrack" type="close" del="true"/>
-  <Symbol name="rsqbrack" type="close" del="true"/>
-  <Symbol name="lsqbrack" type="open" del="true"/>
   <Symbol name="langle" type="open" del="true"/>
   <Symbol name="rangle" type="close" del="true"/>
   <Symbol name="lfloor" type="open" del="true"/>

--- a/src/WpfMath/Data/TexSymbols.xml
+++ b/src/WpfMath/Data/TexSymbols.xml
@@ -64,6 +64,8 @@
 
   <!-- delimiters that can change size -->
 
+  <Symbol name="(" type="open" del="true"/>
+  <Symbol name=")" type="close" del="true"/>
   <Symbol name="lbrace" type="open" del="true"/>
   <Symbol name="rbrace" type="close" del="true"/>
   <Symbol name="lbrack" type="open" del="true"/>

--- a/src/WpfMath/TexEnums.cs
+++ b/src/WpfMath/TexEnums.cs
@@ -1,8 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
 namespace WpfMath
 {
     public enum TexDelimeterType
@@ -34,10 +29,11 @@ namespace WpfMath
         Bottom = 4
     }
 
-    public enum TexDelimeter
+    /// <remarks>The numbers here correspond to the indices in <see cref="TexFormulaParser.DelimiterNames"/>.</remarks>
+    public enum TexDelimiter
     {
         Brace = 0,
-        SquareBracket = 1,
+        Parenthesis = 1,
         Bracket = 2,
         LeftArrow = 3,
         RightArrow = 4,

--- a/src/WpfMath/TexFormulaHelper.cs
+++ b/src/WpfMath/TexFormulaHelper.cs
@@ -249,7 +249,7 @@ namespace WpfMath
             this.Formula.RootAtom = new AccentedAtom(this.source, this.Formula.RootAtom, accentName);
         }
 
-        public void PutDelimiterOver(TexDelimeter delimiter)
+        public void PutDelimiterOver(TexDelimiter delimiter)
         {
             var name = TexFormulaParser.DelimiterNames[(int)delimiter][(int)TexDelimeterType.Over];
             this.Formula.RootAtom = new OverUnderDelimiter(
@@ -262,13 +262,13 @@ namespace WpfMath
                 true);
         }
 
-        public void PutDelimiterOver(TexDelimeter delimiter, string superscriptFormula, TexUnit kernUnit, double kern)
+        public void PutDelimiterOver(TexDelimiter delimiter, string superscriptFormula, TexUnit kernUnit, double kern)
         {
             this.PutDelimiterOver(delimiter, this.formulaParser.Parse(superscriptFormula), kernUnit, kern);
         }
 
         public void PutDelimiterOver(
-            TexDelimeter delimiter,
+            TexDelimiter delimiter,
             TexFormula superscriptFormula,
             TexUnit kernUnit,
             double kern)
@@ -284,7 +284,7 @@ namespace WpfMath
                 true);
         }
 
-        public void PutDelimiterUnder(TexDelimeter delimiter)
+        public void PutDelimiterUnder(TexDelimiter delimiter)
         {
             var name = TexFormulaParser.DelimiterNames[(int)delimiter][(int)TexDelimeterType.Under];
             this.Formula.RootAtom = new OverUnderDelimiter(
@@ -297,12 +297,12 @@ namespace WpfMath
                 false);
         }
 
-        public void PutDelimiterUnder(TexDelimeter delimiter, string subscriptFormula, TexUnit kernUnit, double kern)
+        public void PutDelimiterUnder(TexDelimiter delimiter, string subscriptFormula, TexUnit kernUnit, double kern)
         {
             this.PutDelimiterUnder(delimiter, this.formulaParser.Parse(subscriptFormula), kernUnit, kern);
         }
 
-        public void PutDelimiterUnder(TexDelimeter delimiter, TexFormula subscriptName, TexUnit kernUnit, double kern)
+        public void PutDelimiterUnder(TexDelimiter delimiter, TexFormula subscriptName, TexUnit kernUnit, double kern)
         {
             var name = TexFormulaParser.DelimiterNames[(int)delimiter][(int)TexDelimeterType.Under];
             this.Formula.RootAtom = new OverUnderDelimiter(

--- a/src/WpfMath/TexFormulaParser.cs
+++ b/src/WpfMath/TexFormulaParser.cs
@@ -37,9 +37,8 @@ namespace WpfMath
 
         private static readonly string[][] delimiterNames =
         {
-            new[] { "(", ")" },
             new[] { "lbrace", "rbrace" },
-            new[] { "lsqbrack", "rsqbrack" },
+            new[] { "(", ")" },
             new[] { "lbrack", "rbrack" },
             new[] { "downarrow", "downarrow" },
             new[] { "uparrow", "uparrow" },

--- a/src/WpfMath/TexFormulaParser.cs
+++ b/src/WpfMath/TexFormulaParser.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -10,33 +10,33 @@ using WpfMath.Exceptions;
 
 namespace WpfMath
 {
-  // TODO: Put all error strings into resources.
-  // TODO: Use TextReader for lexing.
-  public class TexFormulaParser
-  {
-    // Special characters for parsing
-    private const char escapeChar = '\\';
-
-    private const char leftGroupChar = '{';
-    private const char rightGroupChar = '}';
-    private const char leftBracketChar = '[';
-    private const char rightBracketChar = ']';
-
-    private const char subScriptChar = '_';
-    private const char superScriptChar = '^';
-    private const char primeChar = '\'';
-
-    // Information used for parsing
-    private static HashSet<string> commands;
-    private static IList<string> symbols;
-    private static IList<string> delimeters;
-    private static HashSet<string> textStyles;
-    private static readonly IDictionary<string, Func<SourceSpan, TexFormula>> predefinedFormulas =
-        new Dictionary<string, Func<SourceSpan, TexFormula>>();
-    private static IDictionary<string, Color> predefinedColors;
-
-    private static readonly string[][] delimiterNames =
+    // TODO: Put all error strings into resources.
+    // TODO: Use TextReader for lexing.
+    public class TexFormulaParser
     {
+        // Special characters for parsing
+        private const char escapeChar = '\\';
+
+        private const char leftGroupChar = '{';
+        private const char rightGroupChar = '}';
+        private const char leftBracketChar = '[';
+        private const char rightBracketChar = ']';
+
+        private const char subScriptChar = '_';
+        private const char superScriptChar = '^';
+        private const char primeChar = '\'';
+
+        // Information used for parsing
+        private static HashSet<string> commands;
+        private static IList<string> symbols;
+        private static IList<string> delimeters;
+        private static HashSet<string> textStyles;
+        private static readonly IDictionary<string, Func<SourceSpan, TexFormula>> predefinedFormulas =
+            new Dictionary<string, Func<SourceSpan, TexFormula>>();
+        private static IDictionary<string, Color> predefinedColors;
+
+        private static readonly string[][] delimiterNames =
+        {
             new[] { "(", ")" },
             new[] { "lbrace", "rbrace" },
             new[] { "lsqbrack", "rsqbrack" },
@@ -51,31 +51,31 @@ namespace WpfMath
             new[] { "Vert", "Vert" }
         };
 
-    static TexFormulaParser()
-    {
-      predefinedColors = new Dictionary<string, Color>();
+        static TexFormulaParser()
+        {
+            predefinedColors = new Dictionary<string, Color>();
 
-      Initialize();
-    }
+            Initialize();
+        }
 
-    internal static string[][] DelimiterNames
-    {
-      get { return delimiterNames; }
-    }
+        internal static string[][] DelimiterNames
+        {
+            get { return delimiterNames; }
+        }
 
-    private static void Initialize()
-    {
-      //
-      // If start application isn't WPF, pack isn't registered by defaultTexFontParser
-      //
-      if (Application.ResourceAssembly == null)
-      {
-        Application.ResourceAssembly = Assembly.GetExecutingAssembly();
-        if (!UriParser.IsKnownScheme("pack"))
-          UriParser.Register(new GenericUriParser(GenericUriParserOptions.GenericAuthority), "pack", -1);
-      }
+        private static void Initialize()
+        {
+            //
+            // If start application isn't WPF, pack isn't registered by defaultTexFontParser
+            //
+            if (Application.ResourceAssembly == null)
+            {
+                Application.ResourceAssembly = Assembly.GetExecutingAssembly();
+                if (!UriParser.IsKnownScheme("pack"))
+                    UriParser.Register(new GenericUriParser(GenericUriParserOptions.GenericAuthority), "pack", -1);
+            }
 
-      commands = new HashSet<string>
+            commands = new HashSet<string>
             {
                 "color",
                 "colorbox",
@@ -87,574 +87,575 @@ namespace WpfMath
                 "underline"
             };
 
-      var formulaSettingsParser = new TexPredefinedFormulaSettingsParser();
-      symbols = formulaSettingsParser.GetSymbolMappings();
-      delimeters = formulaSettingsParser.GetDelimiterMappings();
-      textStyles = formulaSettingsParser.GetTextStyles();
+            var formulaSettingsParser = new TexPredefinedFormulaSettingsParser();
+            symbols = formulaSettingsParser.GetSymbolMappings();
+            delimeters = formulaSettingsParser.GetDelimiterMappings();
+            textStyles = formulaSettingsParser.GetTextStyles();
 
-      var colorParser = new PredefinedColorParser();
-      colorParser.Parse(predefinedColors);
+            var colorParser = new PredefinedColorParser();
+            colorParser.Parse(predefinedColors);
 
-      var predefinedFormulasParser = new TexPredefinedFormulaParser();
-      predefinedFormulasParser.Parse(predefinedFormulas);
-    }
-
-    internal static string GetDelimeterMapping(char character)
-    {
-      try
-      {
-        return delimeters[character];
-      }
-      catch (KeyNotFoundException)
-      {
-        throw new DelimiterMappingNotFoundException(character);
-      }
-    }
-
-    internal static SymbolAtom GetDelimiterSymbol(string name, SourceSpan source)
-    {
-      if (name == null)
-        return null;
-
-      var result = SymbolAtom.GetAtom(name, source);
-      if (!result.IsDelimeter)
-        return null;
-      return result;
-    }
-
-    private static bool IsSymbol(char c)
-    {
-      return !char.IsLetterOrDigit(c);
-    }
-
-    private static bool IsWhiteSpace(char ch)
-    {
-      return ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r';
-    }
-
-    private static bool ShouldSkipWhiteSpace(string style) => style != TexUtilities.TextStyleName;
-
-    public TexFormula Parse(string value, string textStyle = null)
-    {
-      Debug.WriteLine(value);
-      var position = 0;
-      return Parse(new SourceSpan(value, 0, value.Length), ref position, false, textStyle);
-    }
-
-    private TexFormula Parse(SourceSpan value, string textStyle)
-    {
-      int localPostion = 0;
-      return Parse(value, ref localPostion, false, textStyle);
-    }
-
-    private DelimiterInfo ParseUntilDelimiter(SourceSpan value, ref int position, string textStyle)
-    {
-      var embeddedFormula = Parse(value, ref position, true, textStyle);
-      if (embeddedFormula.RootAtom == null)
-        throw new TexParseException("Cannot find closing delimiter");
-
-      var source = embeddedFormula.RootAtom.Source;
-      var bodyRow = embeddedFormula.RootAtom as RowAtom;
-      var lastAtom = bodyRow?.Elements.LastOrDefault() ?? embeddedFormula.RootAtom;
-      var lastDelimiter = lastAtom as SymbolAtom;
-      if (lastDelimiter == null || !lastDelimiter.IsDelimeter)
-        throw new TexParseException($"Cannot find closing delimiter; got {lastDelimiter} instead");
-
-      Atom bodyAtom;
-      if (bodyRow == null)
-      {
-        bodyAtom = new RowAtom(source);
-      }
-      else if (bodyRow.Elements.Count > 2)
-      {
-        var row = bodyRow.Elements.Take(bodyRow.Elements.Count - 1)
-            .Aggregate(new RowAtom(source), (r, atom) => r.Add(atom));
-        bodyAtom = row;
-      }
-      else if (bodyRow.Elements.Count == 2)
-      {
-        bodyAtom = bodyRow.Elements[0];
-      }
-      else
-      {
-        throw new NotSupportedException($"Cannot convert {bodyRow} to fenced atom body");
-      }
-
-      return new DelimiterInfo(bodyAtom, lastDelimiter);
-    }
-
-    private TexFormula Parse(SourceSpan value, ref int position, bool allowClosingDelimiter, string textStyle)
-    {
-      var formula = new TexFormula() { TextStyle = textStyle };
-      var closedDelimiter = false;
-      var skipWhiteSpace = ShouldSkipWhiteSpace(textStyle);
-      var initialPosition = position;
-      while (position < value.Length && !(allowClosingDelimiter && closedDelimiter))
-      {
-        char ch = value[position];
-        var source = value.Segment(position, 1);
-        if (IsWhiteSpace(ch))
-        {
-          if (!skipWhiteSpace)
-          {
-            formula.Add(new SpaceAtom(source), source);
-          }
-
-          position++;
+            var predefinedFormulasParser = new TexPredefinedFormulaParser();
+            predefinedFormulasParser.Parse(predefinedFormulas);
         }
-        else if (ch == escapeChar)
+
+        internal static string GetDelimeterMapping(char character)
         {
-          ProcessEscapeSequence(formula, value, ref position, allowClosingDelimiter, ref closedDelimiter);
-        }
-        else if (ch == leftGroupChar)
-        {
-          var groupValue = ReadElement(value, ref position);
-          var parsedGroup = Parse(groupValue, textStyle);
-          var innerGroupAtom = parsedGroup.RootAtom ?? new RowAtom(groupValue);
-          var groupAtom = new TypedAtom(
-              innerGroupAtom.Source,
-              innerGroupAtom,
-              TexAtomType.Ordinary,
-              TexAtomType.Ordinary);
-          var scriptsAtom = AttachScripts(formula, value, ref position, groupAtom);
-          formula.Add(scriptsAtom, value.Segment(initialPosition, scriptsAtom.Source.Length));
-        }
-        else if (ch == rightGroupChar)
-        {
-          throw new TexParseException("Found a closing '" + rightGroupChar
-              + "' without an opening '" + leftGroupChar + "'!");
-        }
-        else if (ch == superScriptChar || ch == subScriptChar || ch == primeChar)
-        {
-          if (position == 0)
-            throw new TexParseException("Every script needs a base: \""
-                + superScriptChar + "\", \"" + subScriptChar + "\" and \""
-                + primeChar + "\" can't be the first character!");
-          else
-            throw new TexParseException("Double scripts found! Try using more braces.");
-        }
-        else
-        {
-          var scriptsAtom = AttachScripts(
-              formula,
-              value,
-              ref position,
-              ConvertCharacter(formula, ref position, source),
-              skipWhiteSpace);
-          formula.Add(scriptsAtom, value.Segment(initialPosition, position));
-        }
-      }
-
-      return formula;
-    }
-
-    private static SourceSpan ReadElementGroup(SourceSpan value, ref int position, char openChar, char closeChar)
-    {
-      if (position == value.Length || value[position] != openChar)
-        throw new TexParseException("missing '" + openChar + "'!");
-
-      var group = 0;
-      position++;
-      var start = position;
-      while (position < value.Length && !(value[position] == closeChar && group == 0))
-      {
-        if (value[position] == openChar)
-          group++;
-        else if (value[position] == closeChar)
-          group--;
-        position++;
-      }
-
-      if (position == value.Length)
-      {
-        // Reached end of formula but group has not been closed.
-        throw new TexParseException("Illegal end,  missing '" + closeChar + "'!");
-      }
-
-      position++;
-      return value.Segment(start, position - start - 1);
-    }
-
-    /// <summary>Reads an element: typically, a curly brace-enclosed value group or a singular value.</summary>
-    /// <exception cref="TexParseException">Will be thrown for ill-formed groups.</exception>
-    private static SourceSpan ReadElement(SourceSpan value, ref int position)
-    {
-      SkipWhiteSpace(value, ref position);
-
-      if (position == value.Length)
-        throw new TexParseException("An element is missing");
-
-      if (value[position] == leftGroupChar)
-      {
-        return ReadElementGroup(value, ref position, leftGroupChar, rightGroupChar);
-      }
-
-      return value.Segment(position++, 1);
-    }
-
-    private TexFormula ReadScript(TexFormula formula, SourceSpan value, ref int position) =>
-        Parse(ReadElement(value, ref position), formula.TextStyle);
-
-    private Atom ProcessCommand(
-        TexFormula formula,
-        SourceSpan value,
-        ref int position,
-        string command,
-        bool allowClosingDelimiter,
-        ref bool closedDelimiter)
-    {
-      int start = position - command.Length;
-
-      SourceSpan source;
-      switch (command)
-      {
-        case "frac":
-          {
-            var numeratorFormula = Parse(ReadElement(value, ref position), formula.TextStyle);
-            var denominatorFormula = Parse(ReadElement(value, ref position), formula.TextStyle);
-            source = value.Segment(start, position - start);
-            return new FractionAtom(source, numeratorFormula.RootAtom, denominatorFormula.RootAtom, true);
-          }
-        case "left":
-          {
-            SkipWhiteSpace(value, ref position);
-            if (position == value.Length)
-              throw new TexParseException("`left` command should be passed a delimiter");
-
-            var delimiter = value[position];
-            ++position;
-            var left = position;
-
-            var internals = ParseUntilDelimiter(value, ref position, formula.TextStyle);
-
-            var opening = GetDelimiterSymbol(
-                GetDelimeterMapping(delimiter),
-                value.Segment(start, left - start));
-            if (opening == null)
-              throw new TexParseException($"Cannot find delimiter named {delimiter}");
-
-            var closing = internals.ClosingDelimiter;
-            source = value.Segment(start, position - start);
-            return new FencedAtom(source, internals.Body, opening, closing);
-          }
-        case "overline":
-          {
-            var overlineFormula = Parse(ReadElement(value, ref position), formula.TextStyle);
-            source = value.Segment(start, position - start);
-            return new OverlinedAtom(source, overlineFormula.RootAtom);
-          }
-        case "right":
-          {
-            if (!allowClosingDelimiter)
-              throw new TexParseException("`right` command is not allowed without `left`");
-
-            SkipWhiteSpace(value, ref position);
-            if (position == value.Length)
-              throw new TexParseException("`right` command should be passed a delimiter");
-
-            var delimiter = value[position];
-            ++position;
-
-            var closing = GetDelimiterSymbol(
-                GetDelimeterMapping(delimiter),
-                value.Segment(start, position - start));
-            if (closing == null)
-              throw new TexParseException($"Cannot find delimiter named {delimiter}");
-
-            closedDelimiter = true;
-            return closing;
-          }
-        case "sqrt":
-          {
-            // Command is radical.
-            SkipWhiteSpace(value, ref position);
-
-            TexFormula degreeFormula = null;
-            if (value.Length > position && value[position] == leftBracketChar)
+            try
             {
-              // Degree of radical is specified.
-              degreeFormula = Parse(
-                  ReadElementGroup(value, ref position, leftBracketChar, rightBracketChar),
-                  formula.TextStyle);
+                return delimeters[character];
+            }
+            catch (KeyNotFoundException)
+            {
+                throw new DelimiterMappingNotFoundException(character);
+            }
+        }
+
+        internal static SymbolAtom GetDelimiterSymbol(string name, SourceSpan source)
+        {
+            if (name == null)
+                return null;
+
+            var result = SymbolAtom.GetAtom(name, source);
+            if (!result.IsDelimeter)
+                return null;
+            return result;
+        }
+
+        private static bool IsSymbol(char c)
+        {
+            return !char.IsLetterOrDigit(c);
+        }
+
+        private static bool IsWhiteSpace(char ch)
+        {
+            return ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r';
+        }
+
+        private static bool ShouldSkipWhiteSpace(string style) => style != TexUtilities.TextStyleName;
+
+        public TexFormula Parse(string value, string textStyle = null)
+        {
+            Debug.WriteLine(value);
+            var position = 0;
+            return Parse(new SourceSpan(value, 0, value.Length), ref position, false, textStyle);
+        }
+
+        private TexFormula Parse(SourceSpan value, string textStyle)
+        {
+            int localPostion = 0;
+            return Parse(value, ref localPostion, false, textStyle);
+        }
+
+        private DelimiterInfo ParseUntilDelimiter(SourceSpan value, ref int position, string textStyle)
+        {
+            var embeddedFormula = Parse(value, ref position, true, textStyle);
+            if (embeddedFormula.RootAtom == null)
+                throw new TexParseException("Cannot find closing delimiter");
+
+            var source = embeddedFormula.RootAtom.Source;
+            var bodyRow = embeddedFormula.RootAtom as RowAtom;
+            var lastAtom = bodyRow?.Elements.LastOrDefault() ?? embeddedFormula.RootAtom;
+            var lastDelimiter = lastAtom as SymbolAtom;
+            if (lastDelimiter == null || !lastDelimiter.IsDelimeter)
+                throw new TexParseException($"Cannot find closing delimiter; got {lastDelimiter} instead");
+
+            Atom bodyAtom;
+            if (bodyRow == null)
+            {
+                bodyAtom = new RowAtom(source);
+            }
+            else if (bodyRow.Elements.Count > 2)
+            {
+                var row = bodyRow.Elements.Take(bodyRow.Elements.Count - 1)
+                    .Aggregate(new RowAtom(source), (r, atom) => r.Add(atom));
+                bodyAtom = row;
+            }
+            else if (bodyRow.Elements.Count == 2)
+            {
+                bodyAtom = bodyRow.Elements[0];
+            }
+            else
+            {
+                throw new NotSupportedException($"Cannot convert {bodyRow} to fenced atom body");
             }
 
-            var sqrtFormula = Parse(ReadElement(value, ref position), formula.TextStyle);
+            return new DelimiterInfo(bodyAtom, lastDelimiter);
+        }
 
-            source = value.Segment(start, position - start);
-            return new Radical(source, sqrtFormula.RootAtom, degreeFormula?.RootAtom);
-          }
-        case "underline":
-          {
-            var underlineFormula = Parse(ReadElement(value, ref position), formula.TextStyle);
-            source = value.Segment(start, position - start);
-            return new UnderlinedAtom(source, underlineFormula.RootAtom);
-          }
-        case "color":
-          {
-            var colorName = ReadElement(value, ref position);
-            if (!predefinedColors.TryGetValue(colorName.ToString(), out var color))
-              throw new TexParseException($"Color {colorName} not found");
-
-            var bodyValue = ReadElement(value, ref position);
-            var bodyFormula = Parse(bodyValue, formula.TextStyle);
-            source = value.Segment(start, position - start);
-            return new StyledAtom(source, bodyFormula.RootAtom, null, new SolidColorBrush(color));
-          }
-        case "colorbox":
-          {
-            var colorName = ReadElement(value, ref position);
-            var remainingString = ReadElement(value, ref position);
-            var remaining = Parse(remainingString, formula.TextStyle);
-            if (predefinedColors.TryGetValue(colorName.ToString(), out var color))
+        private TexFormula Parse(SourceSpan value, ref int position, bool allowClosingDelimiter, string textStyle)
+        {
+            var formula = new TexFormula() { TextStyle = textStyle };
+            var closedDelimiter = false;
+            var skipWhiteSpace = ShouldSkipWhiteSpace(textStyle);
+            var initialPosition = position;
+            while (position < value.Length && !(allowClosingDelimiter && closedDelimiter))
             {
-              source = value.Segment(start, position - start);
-              return new StyledAtom(source, remaining.RootAtom, new SolidColorBrush(color), null);
+                char ch = value[position];
+                var source = value.Segment(position, 1);
+                if (IsWhiteSpace(ch))
+                {
+                    if (!skipWhiteSpace)
+                    {
+                        formula.Add(new SpaceAtom(source), source);
+                    }
+
+                    position++;
+                }
+                else if (ch == escapeChar)
+                {
+                    ProcessEscapeSequence(formula, value, ref position, allowClosingDelimiter, ref closedDelimiter);
+                }
+                else if (ch == leftGroupChar)
+                {
+                    var groupValue = ReadElement(value, ref position);
+                    var parsedGroup = Parse(groupValue, textStyle);
+                    var innerGroupAtom = parsedGroup.RootAtom ?? new RowAtom(groupValue);
+                    var groupAtom = new TypedAtom(
+                        innerGroupAtom.Source,
+                        innerGroupAtom,
+                        TexAtomType.Ordinary,
+                        TexAtomType.Ordinary);
+                    var scriptsAtom = this.AttachScripts(formula, value, ref position, groupAtom);
+                    formula.Add(scriptsAtom, value.Segment(initialPosition, scriptsAtom.Source.Length));
+                }
+                else if (ch == rightGroupChar)
+                {
+                    throw new TexParseException("Found a closing '" + rightGroupChar
+                        + "' without an opening '" + leftGroupChar + "'!");
+                }
+                else if (ch == superScriptChar || ch == subScriptChar || ch == primeChar)
+                {
+                    if (position == 0)
+                        throw new TexParseException("Every script needs a base: \""
+                            + superScriptChar + "\", \"" + subScriptChar + "\" and \""
+                            + primeChar + "\" can't be the first character!");
+                    else
+                        throw new TexParseException("Double scripts found! Try using more braces.");
+                }
+                else
+                {
+                    var scriptsAtom = this.AttachScripts(
+                        formula,
+                        value,
+                        ref position,
+                        this.ConvertCharacter(formula, ref position, source),
+                        skipWhiteSpace);
+                    formula.Add(scriptsAtom, value.Segment(initialPosition, position));
+                }
             }
 
-            throw new TexParseException($"Color {colorName} not found");
-          }
-      }
+            return formula;
+        }
 
-      throw new TexParseException("Invalid command.");
-    }
-
-    private void ProcessEscapeSequence(
-        TexFormula formula,
-        SourceSpan value,
-        ref int position,
-        bool allowClosingDelimiter,
-        ref bool closedDelimiter)
-    {
-      var initialSrcPosition = position;
-      position++;
-      var start = position;
-      while (position < value.Length)
-      {
-        var ch = value[position];
-        var isEnd = position == value.Length - 1;
-        if (!char.IsLetter(ch) || isEnd)
+        private static SourceSpan ReadElementGroup(SourceSpan value, ref int position, char openChar, char closeChar)
         {
-          // Escape sequence has ended
-          // Or it's a symbol. Assuming in this case it will only be a single char.
-          if ((isEnd && char.IsLetter(ch)) || position - start == 0)
-          {
+            if (position == value.Length || value[position] != openChar)
+                throw new TexParseException("missing '" + openChar + "'!");
+
+            var group = 0;
             position++;
-          }
-          break;
+            var start = position;
+            while (position < value.Length && !(value[position] == closeChar && group == 0))
+            {
+                if (value[position] == openChar)
+                    group++;
+                else if (value[position] == closeChar)
+                    group--;
+                position++;
+            }
+
+            if (position == value.Length)
+            {
+                // Reached end of formula but group has not been closed.
+                throw new TexParseException("Illegal end,  missing '" + closeChar + "'!");
+            }
+
+            position++;
+            return value.Segment(start, position - start - 1);
         }
 
-        position++;
-      }
-
-      var commandSpan = value.Segment(start, position - start);
-      var command = commandSpan.ToString();
-      var formulaSource = new SourceSpan(value.Source, initialSrcPosition, commandSpan.End);
-
-      if (SymbolAtom.TryGetAtom(commandSpan, out var symbolAtom))
-      {
-        // Symbol was found.
-
-        if (symbolAtom.Type == TexAtomType.Accent)
+        /// <summary>Reads an element: typically, a curly brace-enclosed value group or a singular value.</summary>
+        /// <exception cref="TexParseException">Will be thrown for ill-formed groups.</exception>
+        private static SourceSpan ReadElement(SourceSpan value, ref int position)
         {
-          var helper = new TexFormulaHelper(formula, formulaSource);
-          TexFormula accentFormula = ReadScript(formula, value, ref position);
-          helper.AddAccent(accentFormula, symbolAtom.Name);
-        }
-        else if (symbolAtom.Type == TexAtomType.BigOperator)
-        {
-          var opAtom = new BigOperatorAtom(formulaSource, symbolAtom, null, null);
-          formula.Add(AttachScripts(formula, value, ref position, opAtom), formulaSource);
-        }
-        else
-        {
-          formula.Add(AttachScripts(formula, value, ref position, symbolAtom), formulaSource);
-        }
-      }
-      else if (predefinedFormulas.TryGetValue(command, out var factory))
-      {
-        // Predefined formula was found.
-        var predefinedFormula = factory(formulaSource);
-        var atom = AttachScripts(formula, value, ref position, predefinedFormula.RootAtom);
-        formula.Add(atom, formulaSource);
-      }
-      else if (command.Equals("nbsp"))
-      {
-        // Space was found.
-        var atom = AttachScripts(formula, value, ref position, new SpaceAtom(formulaSource));
-        formula.Add(atom, formulaSource);
-      }
-      else if (textStyles.Contains(command))
-      {
-        // Text style was found.
-        SkipWhiteSpace(value, ref position);
-        var styledFormula = Parse(ReadElement(value, ref position), command);
-        if (styledFormula.RootAtom == null)
-          throw new TexParseException("Styled text can't be empty!");
-        var atom = AttachScripts(formula, value, ref position, styledFormula.RootAtom);
-        var source = new SourceSpan(formulaSource.Source, formulaSource.Start, position);
-        formula.Add(atom, source);
-      }
-      else if (commands.Contains(command))
-      {
-        // Command was found.
-        var commandAtom = ProcessCommand(
-            formula,
-            value,
-            ref position,
-            command,
-            allowClosingDelimiter,
-            ref closedDelimiter);
+            SkipWhiteSpace(value, ref position);
 
-        commandAtom = allowClosingDelimiter
-            ? commandAtom
-            : AttachScripts(
-                formula,
-                value,
-                ref position,
-                commandAtom);
+            if (position == value.Length)
+                throw new TexParseException("An element is missing");
 
-        var source = new SourceSpan(formulaSource.Source, formulaSource.Start, commandAtom.Source.End);
-        formula.Add(commandAtom, source);
-      }
-      else
-      {
-        // Escape sequence is invalid.
-        throw new TexParseException("Unknown symbol or command or predefined TeXFormula: '" + command + "'");
-      }
+            if (value[position] == leftGroupChar)
+            {
+                return ReadElementGroup(value, ref position, leftGroupChar, rightGroupChar);
+            }
+
+            return value.Segment(position++, 1);
+        }
+
+        private TexFormula ReadScript(TexFormula formula, SourceSpan value, ref int position) =>
+            this.Parse(ReadElement(value, ref position), formula.TextStyle);
+
+        private Atom ProcessCommand(
+            TexFormula formula,
+            SourceSpan value,
+            ref int position,
+            string command,
+            bool allowClosingDelimiter,
+            ref bool closedDelimiter)
+        {
+            int start = position - command.Length;
+
+            SourceSpan source;
+            switch (command)
+            {
+                case "frac":
+                    {
+                        var numeratorFormula = this.Parse(ReadElement(value, ref position), formula.TextStyle);
+                        var denominatorFormula = this.Parse(ReadElement(value, ref position), formula.TextStyle);
+                        source = value.Segment(start, position - start);
+                        return new FractionAtom(source, numeratorFormula.RootAtom, denominatorFormula.RootAtom, true);
+                    }
+                case "left":
+                    {
+                        SkipWhiteSpace(value, ref position);
+                        if (position == value.Length)
+                            throw new TexParseException("`left` command should be passed a delimiter");
+
+                        var delimiter = value[position];
+                        ++position;
+                        var left = position;
+
+                        var internals = ParseUntilDelimiter(value, ref position, formula.TextStyle);
+
+                        var opening = GetDelimiterSymbol(
+                            GetDelimeterMapping(delimiter),
+                            value.Segment(start, left - start));
+                        if (opening == null)
+                            throw new TexParseException($"Cannot find delimiter named {delimiter}");
+
+                        var closing = internals.ClosingDelimiter;
+                        source = value.Segment(start, position - start);
+                        return new FencedAtom(source, internals.Body, opening, closing);
+                    }
+                case "overline":
+                    {
+                        var overlineFormula = this.Parse(ReadElement(value, ref position), formula.TextStyle);
+                        source = value.Segment(start, position - start);
+                        return new OverlinedAtom(source, overlineFormula.RootAtom);
+                    }
+                case "right":
+                    {
+                        if (!allowClosingDelimiter)
+                            throw new TexParseException("`right` command is not allowed without `left`");
+
+                        SkipWhiteSpace(value, ref position);
+                        if (position == value.Length)
+                            throw new TexParseException("`right` command should be passed a delimiter");
+
+                        var delimiter = value[position];
+                        ++position;
+
+                        var closing = GetDelimiterSymbol(
+                            GetDelimeterMapping(delimiter),
+                            value.Segment(start, position - start));
+                        if (closing == null)
+                            throw new TexParseException($"Cannot find delimiter named {delimiter}");
+
+                        closedDelimiter = true;
+                        return closing;
+                    }
+                case "sqrt":
+                    {
+                        // Command is radical.
+                        SkipWhiteSpace(value, ref position);
+
+                        TexFormula degreeFormula = null;
+                        if (value.Length > position && value[position] == leftBracketChar)
+                        {
+                            // Degree of radical is specified.
+                            degreeFormula = this.Parse(
+                                ReadElementGroup(value, ref position, leftBracketChar, rightBracketChar),
+                                formula.TextStyle);
+                        }
+
+                        var sqrtFormula = this.Parse(ReadElement(value, ref position), formula.TextStyle);
+
+                        source = value.Segment(start, position - start);
+                        return new Radical(source, sqrtFormula.RootAtom, degreeFormula?.RootAtom);
+                    }
+                case "underline":
+                    {
+                        var underlineFormula = this.Parse(ReadElement(value, ref position), formula.TextStyle);
+                        source = value.Segment(start, position - start);
+                        return new UnderlinedAtom(source, underlineFormula.RootAtom);
+                    }
+                case "color":
+                    {
+                        var colorName = ReadElement(value, ref position);
+                        if (!predefinedColors.TryGetValue(colorName.ToString(), out var color))
+                            throw new TexParseException($"Color {colorName} not found");
+
+                        var bodyValue = ReadElement(value, ref position);
+                        var bodyFormula = this.Parse(bodyValue, formula.TextStyle);
+                        source = value.Segment(start, position - start);
+                        return new StyledAtom(source, bodyFormula.RootAtom, null, new SolidColorBrush(color));
+                    }
+                case "colorbox":
+                    {
+                        var colorName = ReadElement(value, ref position);
+                        var remainingString = ReadElement(value, ref position);
+                        var remaining = Parse(remainingString, formula.TextStyle);
+                        if (predefinedColors.TryGetValue(colorName.ToString(), out var color))
+                        {
+                            source = value.Segment(start, position - start);
+                            return new StyledAtom(source, remaining.RootAtom, new SolidColorBrush(color), null);
+                        }
+
+                        throw new TexParseException($"Color {colorName} not found");
+                    }
+            }
+
+            throw new TexParseException("Invalid command.");
+        }
+
+        private void ProcessEscapeSequence(
+            TexFormula formula,
+            SourceSpan value,
+            ref int position,
+            bool allowClosingDelimiter,
+            ref bool closedDelimiter)
+        {
+            var initialSrcPosition = position;
+            position++;
+            var start = position;
+            while (position < value.Length)
+            {
+                var ch = value[position];
+                var isEnd = position == value.Length - 1;
+                if (!char.IsLetter(ch) || isEnd)
+                {
+                    // Escape sequence has ended
+                    // Or it's a symbol. Assuming in this case it will only be a single char.
+                    if ((isEnd && char.IsLetter(ch)) || position - start == 0)
+                    {
+                        position++;
+                    }
+                    break;
+                }
+
+                position++;
+            }
+
+            var commandSpan = value.Segment(start, position - start);
+            var command = commandSpan.ToString();
+            var formulaSource = new SourceSpan(value.Source, initialSrcPosition, commandSpan.End);
+
+            SymbolAtom symbolAtom = null;
+            if (SymbolAtom.TryGetAtom(commandSpan, out symbolAtom))
+            {
+                // Symbol was found.
+
+                if (symbolAtom.Type == TexAtomType.Accent)
+                {
+                    var helper = new TexFormulaHelper(formula, formulaSource);
+                    TexFormula accentFormula = ReadScript(formula, value, ref position);
+                    helper.AddAccent(accentFormula, symbolAtom.Name);
+                }
+                else if (symbolAtom.Type == TexAtomType.BigOperator)
+                {
+                    var opAtom = new BigOperatorAtom(formulaSource, symbolAtom, null, null);
+                    formula.Add(this.AttachScripts(formula, value, ref position, opAtom), formulaSource);
+                }
+                else
+                {
+                    formula.Add(this.AttachScripts(formula, value, ref position, symbolAtom), formulaSource);
+                }
+            }
+            else if (predefinedFormulas.TryGetValue(command, out var factory))
+            {
+                // Predefined formula was found.
+                var predefinedFormula = factory(formulaSource);
+                var atom = this.AttachScripts(formula, value, ref position, predefinedFormula.RootAtom);
+                formula.Add(atom, formulaSource);
+            }
+            else if (command.Equals("nbsp"))
+            {
+                // Space was found.
+                var atom = this.AttachScripts(formula, value, ref position, new SpaceAtom(formulaSource));
+                formula.Add(atom, formulaSource);
+            }
+            else if (textStyles.Contains(command))
+            {
+                // Text style was found.
+                SkipWhiteSpace(value, ref position);
+                var styledFormula = this.Parse(ReadElement(value, ref position), command);
+                if (styledFormula.RootAtom == null)
+                    throw new TexParseException("Styled text can't be empty!");
+                var atom = this.AttachScripts(formula, value, ref position, styledFormula.RootAtom);
+                var source = new SourceSpan(formulaSource.Source, formulaSource.Start, position);
+                formula.Add(atom, source);
+            }
+            else if (commands.Contains(command))
+            {
+                // Command was found.
+                var commandAtom = this.ProcessCommand(
+                    formula,
+                    value,
+                    ref position,
+                    command,
+                    allowClosingDelimiter,
+                    ref closedDelimiter);
+
+                commandAtom = allowClosingDelimiter
+                    ? commandAtom
+                    : AttachScripts(
+                        formula,
+                        value,
+                        ref position,
+                        commandAtom);
+
+                var source = new SourceSpan(formulaSource.Source, formulaSource.Start, commandAtom.Source.End);
+                formula.Add(commandAtom, source);
+            }
+            else
+            {
+                // Escape sequence is invalid.
+                throw new TexParseException("Unknown symbol or command or predefined TeXFormula: '" + command + "'");
+            }
+        }
+
+        private Atom AttachScripts(TexFormula formula, SourceSpan value, ref int position, Atom atom, bool skipWhiteSpace = true)
+        {
+            if (skipWhiteSpace)
+            {
+                SkipWhiteSpace(value, ref position);
+            }
+
+            var initialPosition = position;
+            if (position == value.Length)
+                return atom;
+
+            // Check for prime marks.
+            var primesRowAtom = new RowAtom(new SourceSpan(value.Source, position, 0));
+            int i = position;
+            while (i < value.Length)
+            {
+                if (value[i] == primeChar)
+                {
+                    primesRowAtom = primesRowAtom.Add(SymbolAtom.GetAtom("prime", value.Segment(i, 1)));
+                    position++;
+                }
+                else if (!IsWhiteSpace(value[i]))
+                    break;
+                i++;
+            }
+
+            var primesRowSource = new SourceSpan(
+                value.Source,
+                primesRowAtom.Source.Start,
+                position - primesRowAtom.Source.Start);
+            primesRowAtom = primesRowAtom.WithSource(primesRowSource);
+
+            if (primesRowAtom.Elements.Count > 0)
+                atom = new ScriptsAtom(primesRowAtom.Source, atom, null, primesRowAtom);
+
+            if (position == value.Length)
+                return atom;
+
+            TexFormula superscriptFormula = null;
+            TexFormula subscriptFormula = null;
+
+            var ch = value[position];
+            if (ch == superScriptChar)
+            {
+                // Attach superscript.
+                position++;
+                superscriptFormula = ReadScript(formula, value, ref position);
+
+                SkipWhiteSpace(value, ref position);
+                if (position < value.Length && value[position] == subScriptChar)
+                {
+                    // Attach subscript also.
+                    position++;
+                    subscriptFormula = ReadScript(formula, value, ref position);
+                }
+            }
+            else if (ch == subScriptChar)
+            {
+                // Add subscript.
+                position++;
+                subscriptFormula = ReadScript(formula, value, ref position);
+
+                SkipWhiteSpace(value, ref position);
+                if (position < value.Length && value[position] == superScriptChar)
+                {
+                    // Attach superscript also.
+                    position++;
+                    superscriptFormula = ReadScript(formula, value, ref position);
+                }
+            }
+
+            if (superscriptFormula == null && subscriptFormula == null)
+                return atom;
+
+            // Check whether to return Big Operator or Scripts.
+            var subscriptAtom = subscriptFormula?.RootAtom;
+            var superscriptAtom = superscriptFormula?.RootAtom;
+            if (atom.GetRightType() == TexAtomType.BigOperator)
+            {
+                var source = value.Segment(atom.Source.Start, position - atom.Source.Start);
+                if (atom is BigOperatorAtom typedAtom)
+                {
+                    return new BigOperatorAtom(
+                        source,
+                        typedAtom.BaseAtom,
+                        subscriptAtom,
+                        superscriptAtom,
+                        typedAtom.UseVerticalLimits);
+                }
+
+                return new BigOperatorAtom(source, atom, subscriptAtom, superscriptAtom);
+            }
+            else
+            {
+                var source = new SourceSpan(value.Source, initialPosition, position - initialPosition);
+                return new ScriptsAtom(source, atom, subscriptAtom, superscriptAtom);
+            }
+        }
+
+        private Atom ConvertCharacter(TexFormula formula, ref int position, SourceSpan source)
+        {
+            var character = source[0];
+            position++;
+            if (IsSymbol(character) && formula.TextStyle != TexUtilities.TextStyleName)
+            {
+                // Character is symbol.
+                var symbolName = symbols.ElementAtOrDefault(character);
+                if (string.IsNullOrEmpty(symbolName))
+                    throw new TexParseException($"Unknown character : '{character}'");
+
+                try
+                {
+                    return SymbolAtom.GetAtom(symbolName, source);
+                }
+                catch (SymbolNotFoundException e)
+                {
+                    throw new TexParseException("The character '"
+                            + character.ToString()
+                            + "' was mapped to an unknown symbol with the name '"
+                            + (string)symbolName + "'!", e);
+                }
+            }
+            else // Character is alpha-numeric or should be rendered as text.
+            {
+                return new CharAtom(source, character, formula.TextStyle);
+            }
+        }
+
+        private static void SkipWhiteSpace(SourceSpan value, ref int position)
+        {
+            while (position < value.Length && IsWhiteSpace(value[position]))
+                position++;
+        }
     }
-
-    private Atom AttachScripts(TexFormula formula, SourceSpan value, ref int position, Atom atom, bool skipWhiteSpace = true)
-    {
-      if (skipWhiteSpace)
-      {
-        SkipWhiteSpace(value, ref position);
-      }
-
-      var initialPosition = position;
-      if (position == value.Length)
-        return atom;
-
-      // Check for prime marks.
-      var primesRowAtom = new RowAtom(new SourceSpan(value.Source, position, 0));
-      int i = position;
-      while (i < value.Length)
-      {
-        if (value[i] == primeChar)
-        {
-          primesRowAtom = primesRowAtom.Add(SymbolAtom.GetAtom("prime", value.Segment(i, 1)));
-          position++;
-        }
-        else if (!IsWhiteSpace(value[i]))
-          break;
-        i++;
-      }
-
-      var primesRowSource = new SourceSpan(
-          value.Source,
-          primesRowAtom.Source.Start,
-          position - primesRowAtom.Source.Start);
-      primesRowAtom = primesRowAtom.WithSource(primesRowSource);
-
-      if (primesRowAtom.Elements.Count > 0)
-        atom = new ScriptsAtom(primesRowAtom.Source, atom, null, primesRowAtom);
-
-      if (position == value.Length)
-        return atom;
-
-      TexFormula superscriptFormula = null;
-      TexFormula subscriptFormula = null;
-
-      var ch = value[position];
-      if (ch == superScriptChar)
-      {
-        // Attach superscript.
-        position++;
-        superscriptFormula = ReadScript(formula, value, ref position);
-
-        SkipWhiteSpace(value, ref position);
-        if (position < value.Length && value[position] == subScriptChar)
-        {
-          // Attach subscript also.
-          position++;
-          subscriptFormula = ReadScript(formula, value, ref position);
-        }
-      }
-      else if (ch == subScriptChar)
-      {
-        // Add subscript.
-        position++;
-        subscriptFormula = ReadScript(formula, value, ref position);
-
-        SkipWhiteSpace(value, ref position);
-        if (position < value.Length && value[position] == superScriptChar)
-        {
-          // Attach superscript also.
-          position++;
-          superscriptFormula = ReadScript(formula, value, ref position);
-        }
-      }
-
-      if (superscriptFormula == null && subscriptFormula == null)
-        return atom;
-
-      // Check whether to return Big Operator or Scripts.
-      var subscriptAtom = subscriptFormula?.RootAtom;
-      var superscriptAtom = superscriptFormula?.RootAtom;
-      if (atom.GetRightType() == TexAtomType.BigOperator)
-      {
-        var source = value.Segment(atom.Source.Start, position - atom.Source.Start);
-        if (atom is BigOperatorAtom typedAtom)
-        {
-          return new BigOperatorAtom(
-              source,
-              typedAtom.BaseAtom,
-              subscriptAtom,
-              superscriptAtom,
-              typedAtom.UseVerticalLimits);
-        }
-
-        return new BigOperatorAtom(source, atom, subscriptAtom, superscriptAtom);
-      }
-      else
-      {
-        var source = new SourceSpan(value.Source, initialPosition, position - initialPosition);
-        return new ScriptsAtom(source, atom, subscriptAtom, superscriptAtom);
-      }
-    }
-
-    private Atom ConvertCharacter(TexFormula formula, ref int position, SourceSpan source)
-    {
-      var character = source[0];
-      position++;
-      if (IsSymbol(character) && formula.TextStyle != TexUtilities.TextStyleName)
-      {
-        // Character is symbol.
-        var symbolName = symbols.ElementAtOrDefault(character);
-        if (string.IsNullOrEmpty(symbolName))
-          throw new TexParseException($"Unknown character : '{character}'");
-
-        try
-        {
-          return SymbolAtom.GetAtom(symbolName, source);
-        }
-        catch (SymbolNotFoundException e)
-        {
-          throw new TexParseException("The character '"
-                  + character.ToString()
-                  + "' was mapped to an unknown symbol with the name '"
-                  + symbolName + "'!", e);
-        }
-      }
-      else // Character is alpha-numeric or should be rendered as text.
-      {
-        return new CharAtom(source, character, formula.TextStyle);
-      }
-    }
-
-    private static void SkipWhiteSpace(SourceSpan value, ref int position)
-    {
-      while (position < value.Length && IsWhiteSpace(value[position]))
-        position++;
-    }
-  }
 }

--- a/src/WpfMath/TexFormulaParser.cs
+++ b/src/WpfMath/TexFormulaParser.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -10,33 +10,34 @@ using WpfMath.Exceptions;
 
 namespace WpfMath
 {
-    // TODO: Put all error strings into resources.
-    // TODO: Use TextReader for lexing.
-    public class TexFormulaParser
+  // TODO: Put all error strings into resources.
+  // TODO: Use TextReader for lexing.
+  public class TexFormulaParser
+  {
+    // Special characters for parsing
+    private const char escapeChar = '\\';
+
+    private const char leftGroupChar = '{';
+    private const char rightGroupChar = '}';
+    private const char leftBracketChar = '[';
+    private const char rightBracketChar = ']';
+
+    private const char subScriptChar = '_';
+    private const char superScriptChar = '^';
+    private const char primeChar = '\'';
+
+    // Information used for parsing
+    private static HashSet<string> commands;
+    private static IList<string> symbols;
+    private static IList<string> delimeters;
+    private static HashSet<string> textStyles;
+    private static readonly IDictionary<string, Func<SourceSpan, TexFormula>> predefinedFormulas =
+        new Dictionary<string, Func<SourceSpan, TexFormula>>();
+    private static IDictionary<string, Color> predefinedColors;
+
+    private static readonly string[][] delimiterNames =
     {
-        // Special characters for parsing
-        private const char escapeChar = '\\';
-
-        private const char leftGroupChar = '{';
-        private const char rightGroupChar = '}';
-        private const char leftBracketChar = '[';
-        private const char rightBracketChar = ']';
-
-        private const char subScriptChar = '_';
-        private const char superScriptChar = '^';
-        private const char primeChar = '\'';
-
-        // Information used for parsing
-        private static HashSet<string> commands;
-        private static IList<string> symbols;
-        private static IList<string> delimeters;
-        private static HashSet<string> textStyles;
-        private static readonly IDictionary<string, Func<SourceSpan, TexFormula>> predefinedFormulas =
-            new Dictionary<string, Func<SourceSpan, TexFormula>>();
-        private static IDictionary<string, Color> predefinedColors;
-
-        private static readonly string[][] delimiterNames =
-        {
+            new[] { "(", ")" },
             new[] { "lbrace", "rbrace" },
             new[] { "lsqbrack", "rsqbrack" },
             new[] { "lbrack", "rbrack" },
@@ -50,31 +51,31 @@ namespace WpfMath
             new[] { "Vert", "Vert" }
         };
 
-        static TexFormulaParser()
-        {
-            predefinedColors = new Dictionary<string, Color>();
+    static TexFormulaParser()
+    {
+      predefinedColors = new Dictionary<string, Color>();
 
-            Initialize();
-        }
+      Initialize();
+    }
 
-        internal static string[][] DelimiterNames
-        {
-            get { return delimiterNames; }
-        }
+    internal static string[][] DelimiterNames
+    {
+      get { return delimiterNames; }
+    }
 
-        private static void Initialize()
-        {
-            //
-            // If start application isn't WPF, pack isn't registered by defaultTexFontParser
-            //
-            if (Application.ResourceAssembly == null)
-            {
-                Application.ResourceAssembly = Assembly.GetExecutingAssembly();
-                if (!UriParser.IsKnownScheme("pack"))
-                    UriParser.Register(new GenericUriParser(GenericUriParserOptions.GenericAuthority), "pack", -1);
-            }
+    private static void Initialize()
+    {
+      //
+      // If start application isn't WPF, pack isn't registered by defaultTexFontParser
+      //
+      if (Application.ResourceAssembly == null)
+      {
+        Application.ResourceAssembly = Assembly.GetExecutingAssembly();
+        if (!UriParser.IsKnownScheme("pack"))
+          UriParser.Register(new GenericUriParser(GenericUriParserOptions.GenericAuthority), "pack", -1);
+      }
 
-            commands = new HashSet<string>
+      commands = new HashSet<string>
             {
                 "color",
                 "colorbox",
@@ -86,575 +87,574 @@ namespace WpfMath
                 "underline"
             };
 
-            var formulaSettingsParser = new TexPredefinedFormulaSettingsParser();
-            symbols = formulaSettingsParser.GetSymbolMappings();
-            delimeters = formulaSettingsParser.GetDelimiterMappings();
-            textStyles = formulaSettingsParser.GetTextStyles();
+      var formulaSettingsParser = new TexPredefinedFormulaSettingsParser();
+      symbols = formulaSettingsParser.GetSymbolMappings();
+      delimeters = formulaSettingsParser.GetDelimiterMappings();
+      textStyles = formulaSettingsParser.GetTextStyles();
 
-            var colorParser = new PredefinedColorParser();
-            colorParser.Parse(predefinedColors);
+      var colorParser = new PredefinedColorParser();
+      colorParser.Parse(predefinedColors);
 
-            var predefinedFormulasParser = new TexPredefinedFormulaParser();
-            predefinedFormulasParser.Parse(predefinedFormulas);
-        }
+      var predefinedFormulasParser = new TexPredefinedFormulaParser();
+      predefinedFormulasParser.Parse(predefinedFormulas);
+    }
 
-        internal static string GetDelimeterMapping(char character)
+    internal static string GetDelimeterMapping(char character)
+    {
+      try
+      {
+        return delimeters[character];
+      }
+      catch (KeyNotFoundException)
+      {
+        throw new DelimiterMappingNotFoundException(character);
+      }
+    }
+
+    internal static SymbolAtom GetDelimiterSymbol(string name, SourceSpan source)
+    {
+      if (name == null)
+        return null;
+
+      var result = SymbolAtom.GetAtom(name, source);
+      if (!result.IsDelimeter)
+        return null;
+      return result;
+    }
+
+    private static bool IsSymbol(char c)
+    {
+      return !char.IsLetterOrDigit(c);
+    }
+
+    private static bool IsWhiteSpace(char ch)
+    {
+      return ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r';
+    }
+
+    private static bool ShouldSkipWhiteSpace(string style) => style != TexUtilities.TextStyleName;
+
+    public TexFormula Parse(string value, string textStyle = null)
+    {
+      Debug.WriteLine(value);
+      var position = 0;
+      return Parse(new SourceSpan(value, 0, value.Length), ref position, false, textStyle);
+    }
+
+    private TexFormula Parse(SourceSpan value, string textStyle)
+    {
+      int localPostion = 0;
+      return Parse(value, ref localPostion, false, textStyle);
+    }
+
+    private DelimiterInfo ParseUntilDelimiter(SourceSpan value, ref int position, string textStyle)
+    {
+      var embeddedFormula = Parse(value, ref position, true, textStyle);
+      if (embeddedFormula.RootAtom == null)
+        throw new TexParseException("Cannot find closing delimiter");
+
+      var source = embeddedFormula.RootAtom.Source;
+      var bodyRow = embeddedFormula.RootAtom as RowAtom;
+      var lastAtom = bodyRow?.Elements.LastOrDefault() ?? embeddedFormula.RootAtom;
+      var lastDelimiter = lastAtom as SymbolAtom;
+      if (lastDelimiter == null || !lastDelimiter.IsDelimeter)
+        throw new TexParseException($"Cannot find closing delimiter; got {lastDelimiter} instead");
+
+      Atom bodyAtom;
+      if (bodyRow == null)
+      {
+        bodyAtom = new RowAtom(source);
+      }
+      else if (bodyRow.Elements.Count > 2)
+      {
+        var row = bodyRow.Elements.Take(bodyRow.Elements.Count - 1)
+            .Aggregate(new RowAtom(source), (r, atom) => r.Add(atom));
+        bodyAtom = row;
+      }
+      else if (bodyRow.Elements.Count == 2)
+      {
+        bodyAtom = bodyRow.Elements[0];
+      }
+      else
+      {
+        throw new NotSupportedException($"Cannot convert {bodyRow} to fenced atom body");
+      }
+
+      return new DelimiterInfo(bodyAtom, lastDelimiter);
+    }
+
+    private TexFormula Parse(SourceSpan value, ref int position, bool allowClosingDelimiter, string textStyle)
+    {
+      var formula = new TexFormula() { TextStyle = textStyle };
+      var closedDelimiter = false;
+      var skipWhiteSpace = ShouldSkipWhiteSpace(textStyle);
+      var initialPosition = position;
+      while (position < value.Length && !(allowClosingDelimiter && closedDelimiter))
+      {
+        char ch = value[position];
+        var source = value.Segment(position, 1);
+        if (IsWhiteSpace(ch))
         {
-            try
-            {
-                return delimeters[character];
-            }
-            catch (KeyNotFoundException)
-            {
-                throw new DelimiterMappingNotFoundException(character);
-            }
+          if (!skipWhiteSpace)
+          {
+            formula.Add(new SpaceAtom(source), source);
+          }
+
+          position++;
         }
-
-        internal static SymbolAtom GetDelimiterSymbol(string name, SourceSpan source)
+        else if (ch == escapeChar)
         {
-            if (name == null)
-                return null;
-
-            var result = SymbolAtom.GetAtom(name, source);
-            if (!result.IsDelimeter)
-                return null;
-            return result;
+          ProcessEscapeSequence(formula, value, ref position, allowClosingDelimiter, ref closedDelimiter);
         }
-
-        private static bool IsSymbol(char c)
+        else if (ch == leftGroupChar)
         {
-            return !char.IsLetterOrDigit(c);
+          var groupValue = ReadElement(value, ref position);
+          var parsedGroup = Parse(groupValue, textStyle);
+          var innerGroupAtom = parsedGroup.RootAtom ?? new RowAtom(groupValue);
+          var groupAtom = new TypedAtom(
+              innerGroupAtom.Source,
+              innerGroupAtom,
+              TexAtomType.Ordinary,
+              TexAtomType.Ordinary);
+          var scriptsAtom = AttachScripts(formula, value, ref position, groupAtom);
+          formula.Add(scriptsAtom, value.Segment(initialPosition, scriptsAtom.Source.Length));
         }
-
-        private static bool IsWhiteSpace(char ch)
+        else if (ch == rightGroupChar)
         {
-            return ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r';
+          throw new TexParseException("Found a closing '" + rightGroupChar
+              + "' without an opening '" + leftGroupChar + "'!");
         }
-
-        private static bool ShouldSkipWhiteSpace(string style) => style != TexUtilities.TextStyleName;
-
-        public TexFormula Parse(string value, string textStyle = null)
+        else if (ch == superScriptChar || ch == subScriptChar || ch == primeChar)
         {
-            Debug.WriteLine(value);
-            var position = 0;
-            return Parse(new SourceSpan(value, 0, value.Length), ref position, false, textStyle);
+          if (position == 0)
+            throw new TexParseException("Every script needs a base: \""
+                + superScriptChar + "\", \"" + subScriptChar + "\" and \""
+                + primeChar + "\" can't be the first character!");
+          else
+            throw new TexParseException("Double scripts found! Try using more braces.");
         }
-
-        private TexFormula Parse(SourceSpan value, string textStyle)
+        else
         {
-            int localPostion = 0;
-            return Parse(value, ref localPostion, false, textStyle);
+          var scriptsAtom = AttachScripts(
+              formula,
+              value,
+              ref position,
+              ConvertCharacter(formula, ref position, source),
+              skipWhiteSpace);
+          formula.Add(scriptsAtom, value.Segment(initialPosition, position));
         }
+      }
 
-        private DelimiterInfo ParseUntilDelimiter(SourceSpan value, ref int position, string textStyle)
-        {
-            var embeddedFormula = Parse(value, ref position, true, textStyle);
-            if (embeddedFormula.RootAtom == null)
-                throw new TexParseException("Cannot find closing delimiter");
+      return formula;
+    }
 
-            var source = embeddedFormula.RootAtom.Source;
-            var bodyRow = embeddedFormula.RootAtom as RowAtom;
-            var lastAtom = bodyRow?.Elements.LastOrDefault() ?? embeddedFormula.RootAtom;
-            var lastDelimiter = lastAtom as SymbolAtom;
-            if (lastDelimiter == null || !lastDelimiter.IsDelimeter)
-                throw new TexParseException($"Cannot find closing delimiter; got {lastDelimiter} instead");
+    private static SourceSpan ReadElementGroup(SourceSpan value, ref int position, char openChar, char closeChar)
+    {
+      if (position == value.Length || value[position] != openChar)
+        throw new TexParseException("missing '" + openChar + "'!");
 
-            Atom bodyAtom;
-            if (bodyRow == null)
-            {
-                bodyAtom = new RowAtom(source);
-            }
-            else if (bodyRow.Elements.Count > 2)
-            {
-                var row = bodyRow.Elements.Take(bodyRow.Elements.Count - 1)
-                    .Aggregate(new RowAtom(source), (r, atom) => r.Add(atom));
-                bodyAtom = row;
-            }
-            else if (bodyRow.Elements.Count == 2)
-            {
-                bodyAtom = bodyRow.Elements[0];
-            }
-            else
-            {
-                throw new NotSupportedException($"Cannot convert {bodyRow} to fenced atom body");
-            }
+      var group = 0;
+      position++;
+      var start = position;
+      while (position < value.Length && !(value[position] == closeChar && group == 0))
+      {
+        if (value[position] == openChar)
+          group++;
+        else if (value[position] == closeChar)
+          group--;
+        position++;
+      }
 
-            return new DelimiterInfo(bodyAtom, lastDelimiter);
-        }
+      if (position == value.Length)
+      {
+        // Reached end of formula but group has not been closed.
+        throw new TexParseException("Illegal end,  missing '" + closeChar + "'!");
+      }
 
-        private TexFormula Parse(SourceSpan value, ref int position, bool allowClosingDelimiter, string textStyle)
-        {
-            var formula = new TexFormula() { TextStyle = textStyle };
-            var closedDelimiter = false;
-            var skipWhiteSpace = ShouldSkipWhiteSpace(textStyle);
-            var initialPosition = position;
-            while (position < value.Length && !(allowClosingDelimiter && closedDelimiter))
-            {
-                char ch = value[position];
-                var source = value.Segment(position, 1);
-                if (IsWhiteSpace(ch))
-                {
-                    if (!skipWhiteSpace)
-                    {
-                        formula.Add(new SpaceAtom(source), source);
-                    }
+      position++;
+      return value.Segment(start, position - start - 1);
+    }
 
-                    position++;
-                }
-                else if (ch == escapeChar)
-                {
-                    ProcessEscapeSequence(formula, value, ref position, allowClosingDelimiter, ref closedDelimiter);
-                }
-                else if (ch == leftGroupChar)
-                {
-                    var groupValue = ReadElement(value, ref position);
-                    var parsedGroup = Parse(groupValue, textStyle);
-                    var innerGroupAtom = parsedGroup.RootAtom ?? new RowAtom(groupValue);
-                    var groupAtom = new TypedAtom(
-                        innerGroupAtom.Source,
-                        innerGroupAtom,
-                        TexAtomType.Ordinary,
-                        TexAtomType.Ordinary);
-                    var scriptsAtom = this.AttachScripts(formula, value, ref position, groupAtom);
-                    formula.Add(scriptsAtom, value.Segment(initialPosition, scriptsAtom.Source.Length));
-                }
-                else if (ch == rightGroupChar)
-                {
-                    throw new TexParseException("Found a closing '" + rightGroupChar
-                        + "' without an opening '" + leftGroupChar + "'!");
-                }
-                else if (ch == superScriptChar || ch == subScriptChar || ch == primeChar)
-                {
-                    if (position == 0)
-                        throw new TexParseException("Every script needs a base: \""
-                            + superScriptChar + "\", \"" + subScriptChar + "\" and \""
-                            + primeChar + "\" can't be the first character!");
-                    else
-                        throw new TexParseException("Double scripts found! Try using more braces.");
-                }
-                else
-                {
-                    var scriptsAtom = this.AttachScripts(
-                        formula,
-                        value,
-                        ref position,
-                        this.ConvertCharacter(formula, ref position, source),
-                        skipWhiteSpace);
-                    formula.Add(scriptsAtom, value.Segment(initialPosition, position));
-                }
-            }
+    /// <summary>Reads an element: typically, a curly brace-enclosed value group or a singular value.</summary>
+    /// <exception cref="TexParseException">Will be thrown for ill-formed groups.</exception>
+    private static SourceSpan ReadElement(SourceSpan value, ref int position)
+    {
+      SkipWhiteSpace(value, ref position);
 
-            return formula;
-        }
+      if (position == value.Length)
+        throw new TexParseException("An element is missing");
 
-        private static SourceSpan ReadElementGroup(SourceSpan value, ref int position, char openChar, char closeChar)
-        {
-            if (position == value.Length || value[position] != openChar)
-                throw new TexParseException("missing '" + openChar + "'!");
+      if (value[position] == leftGroupChar)
+      {
+        return ReadElementGroup(value, ref position, leftGroupChar, rightGroupChar);
+      }
 
-            var group = 0;
-            position++;
-            var start = position;
-            while (position < value.Length && !(value[position] == closeChar && group == 0))
-            {
-                if (value[position] == openChar)
-                    group++;
-                else if (value[position] == closeChar)
-                    group--;
-                position++;
-            }
+      return value.Segment(position++, 1);
+    }
 
+    private TexFormula ReadScript(TexFormula formula, SourceSpan value, ref int position) =>
+        Parse(ReadElement(value, ref position), formula.TextStyle);
+
+    private Atom ProcessCommand(
+        TexFormula formula,
+        SourceSpan value,
+        ref int position,
+        string command,
+        bool allowClosingDelimiter,
+        ref bool closedDelimiter)
+    {
+      int start = position - command.Length;
+
+      SourceSpan source;
+      switch (command)
+      {
+        case "frac":
+          {
+            var numeratorFormula = Parse(ReadElement(value, ref position), formula.TextStyle);
+            var denominatorFormula = Parse(ReadElement(value, ref position), formula.TextStyle);
+            source = value.Segment(start, position - start);
+            return new FractionAtom(source, numeratorFormula.RootAtom, denominatorFormula.RootAtom, true);
+          }
+        case "left":
+          {
+            SkipWhiteSpace(value, ref position);
             if (position == value.Length)
-            {
-                // Reached end of formula but group has not been closed.
-                throw new TexParseException("Illegal end,  missing '" + closeChar + "'!");
-            }
+              throw new TexParseException("`left` command should be passed a delimiter");
 
-            position++;
-            return value.Segment(start, position - start - 1);
-        }
+            var delimiter = value[position];
+            ++position;
+            var left = position;
 
-        /// <summary>Reads an element: typically, a curly brace-enclosed value group or a singular value.</summary>
-        /// <exception cref="TexParseException">Will be thrown for ill-formed groups.</exception>
-        private static SourceSpan ReadElement(SourceSpan value, ref int position)
-        {
+            var internals = ParseUntilDelimiter(value, ref position, formula.TextStyle);
+
+            var opening = GetDelimiterSymbol(
+                GetDelimeterMapping(delimiter),
+                value.Segment(start, left - start));
+            if (opening == null)
+              throw new TexParseException($"Cannot find delimiter named {delimiter}");
+
+            var closing = internals.ClosingDelimiter;
+            source = value.Segment(start, position - start);
+            return new FencedAtom(source, internals.Body, opening, closing);
+          }
+        case "overline":
+          {
+            var overlineFormula = Parse(ReadElement(value, ref position), formula.TextStyle);
+            source = value.Segment(start, position - start);
+            return new OverlinedAtom(source, overlineFormula.RootAtom);
+          }
+        case "right":
+          {
+            if (!allowClosingDelimiter)
+              throw new TexParseException("`right` command is not allowed without `left`");
+
+            SkipWhiteSpace(value, ref position);
+            if (position == value.Length)
+              throw new TexParseException("`right` command should be passed a delimiter");
+
+            var delimiter = value[position];
+            ++position;
+
+            var closing = GetDelimiterSymbol(
+                GetDelimeterMapping(delimiter),
+                value.Segment(start, position - start));
+            if (closing == null)
+              throw new TexParseException($"Cannot find delimiter named {delimiter}");
+
+            closedDelimiter = true;
+            return closing;
+          }
+        case "sqrt":
+          {
+            // Command is radical.
             SkipWhiteSpace(value, ref position);
 
-            if (position == value.Length)
-                throw new TexParseException("An element is missing");
-
-            if (value[position] == leftGroupChar)
+            TexFormula degreeFormula = null;
+            if (value.Length > position && value[position] == leftBracketChar)
             {
-                return ReadElementGroup(value, ref position, leftGroupChar, rightGroupChar);
+              // Degree of radical is specified.
+              degreeFormula = Parse(
+                  ReadElementGroup(value, ref position, leftBracketChar, rightBracketChar),
+                  formula.TextStyle);
             }
 
-            return value.Segment(position++, 1);
-        }
+            var sqrtFormula = Parse(ReadElement(value, ref position), formula.TextStyle);
 
-        private TexFormula ReadScript(TexFormula formula, SourceSpan value, ref int position) =>
-            this.Parse(ReadElement(value, ref position), formula.TextStyle);
+            source = value.Segment(start, position - start);
+            return new Radical(source, sqrtFormula.RootAtom, degreeFormula?.RootAtom);
+          }
+        case "underline":
+          {
+            var underlineFormula = Parse(ReadElement(value, ref position), formula.TextStyle);
+            source = value.Segment(start, position - start);
+            return new UnderlinedAtom(source, underlineFormula.RootAtom);
+          }
+        case "color":
+          {
+            var colorName = ReadElement(value, ref position);
+            if (!predefinedColors.TryGetValue(colorName.ToString(), out var color))
+              throw new TexParseException($"Color {colorName} not found");
 
-        private Atom ProcessCommand(
-            TexFormula formula,
-            SourceSpan value,
-            ref int position,
-            string command,
-            bool allowClosingDelimiter,
-            ref bool closedDelimiter)
-        {
-            int start = position - command.Length;
-
-            SourceSpan source;
-            switch (command)
+            var bodyValue = ReadElement(value, ref position);
+            var bodyFormula = Parse(bodyValue, formula.TextStyle);
+            source = value.Segment(start, position - start);
+            return new StyledAtom(source, bodyFormula.RootAtom, null, new SolidColorBrush(color));
+          }
+        case "colorbox":
+          {
+            var colorName = ReadElement(value, ref position);
+            var remainingString = ReadElement(value, ref position);
+            var remaining = Parse(remainingString, formula.TextStyle);
+            if (predefinedColors.TryGetValue(colorName.ToString(), out var color))
             {
-                case "frac":
-                    {
-                        var numeratorFormula = this.Parse(ReadElement(value, ref position), formula.TextStyle);
-                        var denominatorFormula = this.Parse(ReadElement(value, ref position), formula.TextStyle);
-                        source = value.Segment(start, position - start);
-                        return new FractionAtom(source, numeratorFormula.RootAtom, denominatorFormula.RootAtom, true);
-                    }
-                case "left":
-                    {
-                        SkipWhiteSpace(value, ref position);
-                        if (position == value.Length)
-                            throw new TexParseException("`left` command should be passed a delimiter");
-
-                        var delimiter = value[position];
-                        ++position;
-                        var left = position;
-
-                        var internals = ParseUntilDelimiter(value, ref position, formula.TextStyle);
-
-                        var opening = GetDelimiterSymbol(
-                            GetDelimeterMapping(delimiter),
-                            value.Segment(start, left - start));
-                        if (opening == null)
-                            throw new TexParseException($"Cannot find delimiter named {delimiter}");
-
-                        var closing = internals.ClosingDelimiter;
-                        source = value.Segment(start, position - start);
-                        return new FencedAtom(source, internals.Body, opening, closing);
-                    }
-                case "overline":
-                    {
-                        var overlineFormula = this.Parse(ReadElement(value, ref position), formula.TextStyle);
-                        source = value.Segment(start, position - start);
-                        return new OverlinedAtom(source, overlineFormula.RootAtom);
-                    }
-                case "right":
-                    {
-                        if (!allowClosingDelimiter)
-                            throw new TexParseException("`right` command is not allowed without `left`");
-
-                        SkipWhiteSpace(value, ref position);
-                        if (position == value.Length)
-                            throw new TexParseException("`right` command should be passed a delimiter");
-
-                        var delimiter = value[position];
-                        ++position;
-
-                        var closing = GetDelimiterSymbol(
-                            GetDelimeterMapping(delimiter),
-                            value.Segment(start, position - start));
-                        if (closing == null)
-                            throw new TexParseException($"Cannot find delimiter named {delimiter}");
-
-                        closedDelimiter = true;
-                        return closing;
-                    }
-                case "sqrt":
-                    {
-                        // Command is radical.
-                        SkipWhiteSpace(value, ref position);
-
-                        TexFormula degreeFormula = null;
-                        if (value.Length > position && value[position] == leftBracketChar)
-                        {
-                            // Degree of radical is specified.
-                            degreeFormula = this.Parse(
-                                ReadElementGroup(value, ref position, leftBracketChar, rightBracketChar),
-                                formula.TextStyle);
-                        }
-
-                        var sqrtFormula = this.Parse(ReadElement(value, ref position), formula.TextStyle);
-
-                        source = value.Segment(start, position - start);
-                        return new Radical(source, sqrtFormula.RootAtom, degreeFormula?.RootAtom);
-                    }
-                case "underline":
-                    {
-                        var underlineFormula = this.Parse(ReadElement(value, ref position), formula.TextStyle);
-                        source = value.Segment(start, position - start);
-                        return new UnderlinedAtom(source, underlineFormula.RootAtom);
-                    }
-                case "color":
-                    {
-                        var colorName = ReadElement(value, ref position);
-                        if (!predefinedColors.TryGetValue(colorName.ToString(), out var color))
-                            throw new TexParseException($"Color {colorName} not found");
-
-                        var bodyValue = ReadElement(value, ref position);
-                        var bodyFormula = this.Parse(bodyValue, formula.TextStyle);
-                        source = value.Segment(start, position - start);
-                        return new StyledAtom(source, bodyFormula.RootAtom, null, new SolidColorBrush(color));
-                    }
-                case "colorbox":
-                    {
-                        var colorName = ReadElement(value, ref position);
-                        var remainingString = ReadElement(value, ref position);
-                        var remaining = Parse(remainingString, formula.TextStyle);
-                        if (predefinedColors.TryGetValue(colorName.ToString(), out var color))
-                        {
-                            source = value.Segment(start, position - start);
-                            return new StyledAtom(source, remaining.RootAtom, new SolidColorBrush(color), null);
-                        }
-
-                        throw new TexParseException($"Color {colorName} not found");
-                    }
+              source = value.Segment(start, position - start);
+              return new StyledAtom(source, remaining.RootAtom, new SolidColorBrush(color), null);
             }
 
-            throw new TexParseException("Invalid command.");
-        }
+            throw new TexParseException($"Color {colorName} not found");
+          }
+      }
 
-        private void ProcessEscapeSequence(
-            TexFormula formula,
-            SourceSpan value,
-            ref int position,
-            bool allowClosingDelimiter,
-            ref bool closedDelimiter)
-        {
-            var initialSrcPosition = position;
-            position++;
-            var start = position;
-            while (position < value.Length)
-            {
-                var ch = value[position];
-                var isEnd = position == value.Length - 1;
-                if (!char.IsLetter(ch) || isEnd)
-                {
-                    // Escape sequence has ended
-                    // Or it's a symbol. Assuming in this case it will only be a single char.
-                    if ((isEnd && char.IsLetter(ch)) || position - start == 0)
-                    {
-                        position++;
-                    }
-                    break;
-                }
-
-                position++;
-            }
-
-            var commandSpan = value.Segment(start, position - start);
-            var command = commandSpan.ToString();
-            var formulaSource = new SourceSpan(value.Source, initialSrcPosition, commandSpan.End);
-
-            SymbolAtom symbolAtom = null;
-            if (SymbolAtom.TryGetAtom(commandSpan, out symbolAtom))
-            {
-                // Symbol was found.
-
-                if (symbolAtom.Type == TexAtomType.Accent)
-                {
-                    var helper = new TexFormulaHelper(formula, formulaSource);
-                    TexFormula accentFormula = ReadScript(formula, value, ref position);
-                    helper.AddAccent(accentFormula, symbolAtom.Name);
-                }
-                else if (symbolAtom.Type == TexAtomType.BigOperator)
-                {
-                    var opAtom = new BigOperatorAtom(formulaSource, symbolAtom, null, null);
-                    formula.Add(this.AttachScripts(formula, value, ref position, opAtom), formulaSource);
-                }
-                else
-                {
-                    formula.Add(this.AttachScripts(formula, value, ref position, symbolAtom), formulaSource);
-                }
-            }
-            else if (predefinedFormulas.TryGetValue(command, out var factory))
-            {
-                // Predefined formula was found.
-                var predefinedFormula = factory(formulaSource);
-                var atom = this.AttachScripts(formula, value, ref position, predefinedFormula.RootAtom);
-                formula.Add(atom, formulaSource);
-            }
-            else if (command.Equals("nbsp"))
-            {
-                // Space was found.
-                var atom = this.AttachScripts(formula, value, ref position, new SpaceAtom(formulaSource));
-                formula.Add(atom, formulaSource);
-            }
-            else if (textStyles.Contains(command))
-            {
-                // Text style was found.
-                SkipWhiteSpace(value, ref position);
-                var styledFormula = this.Parse(ReadElement(value, ref position), command);
-                if (styledFormula.RootAtom == null)
-                    throw new TexParseException("Styled text can't be empty!");
-                var atom = this.AttachScripts(formula, value, ref position, styledFormula.RootAtom);
-                var source = new SourceSpan(formulaSource.Source, formulaSource.Start, position);
-                formula.Add(atom, source);
-            }
-            else if (commands.Contains(command))
-            {
-                // Command was found.
-                var commandAtom = this.ProcessCommand(
-                    formula,
-                    value,
-                    ref position,
-                    command,
-                    allowClosingDelimiter,
-                    ref closedDelimiter);
-
-                commandAtom = allowClosingDelimiter
-                    ? commandAtom
-                    : AttachScripts(
-                        formula,
-                        value,
-                        ref position,
-                        commandAtom);
-
-                var source = new SourceSpan(formulaSource.Source, formulaSource.Start, commandAtom.Source.End);
-                formula.Add(commandAtom, source);
-            }
-            else
-            {
-                // Escape sequence is invalid.
-                throw new TexParseException("Unknown symbol or command or predefined TeXFormula: '" + command + "'");
-            }
-        }
-
-        private Atom AttachScripts(TexFormula formula, SourceSpan value, ref int position, Atom atom, bool skipWhiteSpace = true)
-        {
-            if (skipWhiteSpace)
-            {
-                SkipWhiteSpace(value, ref position);
-            }
-
-            var initialPosition = position;
-            if (position == value.Length)
-                return atom;
-
-            // Check for prime marks.
-            var primesRowAtom = new RowAtom(new SourceSpan(value.Source, position, 0));
-            int i = position;
-            while (i < value.Length)
-            {
-                if (value[i] == primeChar)
-                {
-                    primesRowAtom = primesRowAtom.Add(SymbolAtom.GetAtom("prime", value.Segment(i, 1)));
-                    position++;
-                }
-                else if (!IsWhiteSpace(value[i]))
-                    break;
-                i++;
-            }
-
-            var primesRowSource = new SourceSpan(
-                value.Source,
-                primesRowAtom.Source.Start,
-                position - primesRowAtom.Source.Start);
-            primesRowAtom = primesRowAtom.WithSource(primesRowSource);
-
-            if (primesRowAtom.Elements.Count > 0)
-                atom = new ScriptsAtom(primesRowAtom.Source, atom, null, primesRowAtom);
-
-            if (position == value.Length)
-                return atom;
-
-            TexFormula superscriptFormula = null;
-            TexFormula subscriptFormula = null;
-
-            var ch = value[position];
-            if (ch == superScriptChar)
-            {
-                // Attach superscript.
-                position++;
-                superscriptFormula = ReadScript(formula, value, ref position);
-
-                SkipWhiteSpace(value, ref position);
-                if (position < value.Length && value[position] == subScriptChar)
-                {
-                    // Attach subscript also.
-                    position++;
-                    subscriptFormula = ReadScript(formula, value, ref position);
-                }
-            }
-            else if (ch == subScriptChar)
-            {
-                // Add subscript.
-                position++;
-                subscriptFormula = ReadScript(formula, value, ref position);
-
-                SkipWhiteSpace(value, ref position);
-                if (position < value.Length && value[position] == superScriptChar)
-                {
-                    // Attach superscript also.
-                    position++;
-                    superscriptFormula = ReadScript(formula, value, ref position);
-                }
-            }
-
-            if (superscriptFormula == null && subscriptFormula == null)
-                return atom;
-
-            // Check whether to return Big Operator or Scripts.
-            var subscriptAtom = subscriptFormula?.RootAtom;
-            var superscriptAtom = superscriptFormula?.RootAtom;
-            if (atom.GetRightType() == TexAtomType.BigOperator)
-            {
-                var source = value.Segment(atom.Source.Start, position - atom.Source.Start);
-                if (atom is BigOperatorAtom typedAtom)
-                {
-                    return new BigOperatorAtom(
-                        source,
-                        typedAtom.BaseAtom,
-                        subscriptAtom,
-                        superscriptAtom,
-                        typedAtom.UseVerticalLimits);
-                }
-
-                return new BigOperatorAtom(source, atom, subscriptAtom, superscriptAtom);
-            }
-            else
-            {
-                var source = new SourceSpan(value.Source, initialPosition, position - initialPosition);
-                return new ScriptsAtom(source, atom, subscriptAtom, superscriptAtom);
-            }
-        }
-
-        private Atom ConvertCharacter(TexFormula formula, ref int position, SourceSpan source)
-        {
-            var character = source[0];
-            position++;
-            if (IsSymbol(character) && formula.TextStyle != TexUtilities.TextStyleName)
-            {
-                // Character is symbol.
-                var symbolName = symbols.ElementAtOrDefault(character);
-                if (string.IsNullOrEmpty(symbolName))
-                    throw new TexParseException($"Unknown character : '{character}'");
-
-                try
-                {
-                    return SymbolAtom.GetAtom(symbolName, source);
-                }
-                catch (SymbolNotFoundException e)
-                {
-                    throw new TexParseException("The character '"
-                            + character.ToString()
-                            + "' was mapped to an unknown symbol with the name '"
-                            + (string)symbolName + "'!", e);
-                }
-            }
-            else // Character is alpha-numeric or should be rendered as text.
-            {
-                return new CharAtom(source, character, formula.TextStyle);
-            }
-        }
-
-        private static void SkipWhiteSpace(SourceSpan value, ref int position)
-        {
-            while (position < value.Length && IsWhiteSpace(value[position]))
-                position++;
-        }
+      throw new TexParseException("Invalid command.");
     }
+
+    private void ProcessEscapeSequence(
+        TexFormula formula,
+        SourceSpan value,
+        ref int position,
+        bool allowClosingDelimiter,
+        ref bool closedDelimiter)
+    {
+      var initialSrcPosition = position;
+      position++;
+      var start = position;
+      while (position < value.Length)
+      {
+        var ch = value[position];
+        var isEnd = position == value.Length - 1;
+        if (!char.IsLetter(ch) || isEnd)
+        {
+          // Escape sequence has ended
+          // Or it's a symbol. Assuming in this case it will only be a single char.
+          if ((isEnd && char.IsLetter(ch)) || position - start == 0)
+          {
+            position++;
+          }
+          break;
+        }
+
+        position++;
+      }
+
+      var commandSpan = value.Segment(start, position - start);
+      var command = commandSpan.ToString();
+      var formulaSource = new SourceSpan(value.Source, initialSrcPosition, commandSpan.End);
+
+      if (SymbolAtom.TryGetAtom(commandSpan, out var symbolAtom))
+      {
+        // Symbol was found.
+
+        if (symbolAtom.Type == TexAtomType.Accent)
+        {
+          var helper = new TexFormulaHelper(formula, formulaSource);
+          TexFormula accentFormula = ReadScript(formula, value, ref position);
+          helper.AddAccent(accentFormula, symbolAtom.Name);
+        }
+        else if (symbolAtom.Type == TexAtomType.BigOperator)
+        {
+          var opAtom = new BigOperatorAtom(formulaSource, symbolAtom, null, null);
+          formula.Add(AttachScripts(formula, value, ref position, opAtom), formulaSource);
+        }
+        else
+        {
+          formula.Add(AttachScripts(formula, value, ref position, symbolAtom), formulaSource);
+        }
+      }
+      else if (predefinedFormulas.TryGetValue(command, out var factory))
+      {
+        // Predefined formula was found.
+        var predefinedFormula = factory(formulaSource);
+        var atom = AttachScripts(formula, value, ref position, predefinedFormula.RootAtom);
+        formula.Add(atom, formulaSource);
+      }
+      else if (command.Equals("nbsp"))
+      {
+        // Space was found.
+        var atom = AttachScripts(formula, value, ref position, new SpaceAtom(formulaSource));
+        formula.Add(atom, formulaSource);
+      }
+      else if (textStyles.Contains(command))
+      {
+        // Text style was found.
+        SkipWhiteSpace(value, ref position);
+        var styledFormula = Parse(ReadElement(value, ref position), command);
+        if (styledFormula.RootAtom == null)
+          throw new TexParseException("Styled text can't be empty!");
+        var atom = AttachScripts(formula, value, ref position, styledFormula.RootAtom);
+        var source = new SourceSpan(formulaSource.Source, formulaSource.Start, position);
+        formula.Add(atom, source);
+      }
+      else if (commands.Contains(command))
+      {
+        // Command was found.
+        var commandAtom = ProcessCommand(
+            formula,
+            value,
+            ref position,
+            command,
+            allowClosingDelimiter,
+            ref closedDelimiter);
+
+        commandAtom = allowClosingDelimiter
+            ? commandAtom
+            : AttachScripts(
+                formula,
+                value,
+                ref position,
+                commandAtom);
+
+        var source = new SourceSpan(formulaSource.Source, formulaSource.Start, commandAtom.Source.End);
+        formula.Add(commandAtom, source);
+      }
+      else
+      {
+        // Escape sequence is invalid.
+        throw new TexParseException("Unknown symbol or command or predefined TeXFormula: '" + command + "'");
+      }
+    }
+
+    private Atom AttachScripts(TexFormula formula, SourceSpan value, ref int position, Atom atom, bool skipWhiteSpace = true)
+    {
+      if (skipWhiteSpace)
+      {
+        SkipWhiteSpace(value, ref position);
+      }
+
+      var initialPosition = position;
+      if (position == value.Length)
+        return atom;
+
+      // Check for prime marks.
+      var primesRowAtom = new RowAtom(new SourceSpan(value.Source, position, 0));
+      int i = position;
+      while (i < value.Length)
+      {
+        if (value[i] == primeChar)
+        {
+          primesRowAtom = primesRowAtom.Add(SymbolAtom.GetAtom("prime", value.Segment(i, 1)));
+          position++;
+        }
+        else if (!IsWhiteSpace(value[i]))
+          break;
+        i++;
+      }
+
+      var primesRowSource = new SourceSpan(
+          value.Source,
+          primesRowAtom.Source.Start,
+          position - primesRowAtom.Source.Start);
+      primesRowAtom = primesRowAtom.WithSource(primesRowSource);
+
+      if (primesRowAtom.Elements.Count > 0)
+        atom = new ScriptsAtom(primesRowAtom.Source, atom, null, primesRowAtom);
+
+      if (position == value.Length)
+        return atom;
+
+      TexFormula superscriptFormula = null;
+      TexFormula subscriptFormula = null;
+
+      var ch = value[position];
+      if (ch == superScriptChar)
+      {
+        // Attach superscript.
+        position++;
+        superscriptFormula = ReadScript(formula, value, ref position);
+
+        SkipWhiteSpace(value, ref position);
+        if (position < value.Length && value[position] == subScriptChar)
+        {
+          // Attach subscript also.
+          position++;
+          subscriptFormula = ReadScript(formula, value, ref position);
+        }
+      }
+      else if (ch == subScriptChar)
+      {
+        // Add subscript.
+        position++;
+        subscriptFormula = ReadScript(formula, value, ref position);
+
+        SkipWhiteSpace(value, ref position);
+        if (position < value.Length && value[position] == superScriptChar)
+        {
+          // Attach superscript also.
+          position++;
+          superscriptFormula = ReadScript(formula, value, ref position);
+        }
+      }
+
+      if (superscriptFormula == null && subscriptFormula == null)
+        return atom;
+
+      // Check whether to return Big Operator or Scripts.
+      var subscriptAtom = subscriptFormula?.RootAtom;
+      var superscriptAtom = superscriptFormula?.RootAtom;
+      if (atom.GetRightType() == TexAtomType.BigOperator)
+      {
+        var source = value.Segment(atom.Source.Start, position - atom.Source.Start);
+        if (atom is BigOperatorAtom typedAtom)
+        {
+          return new BigOperatorAtom(
+              source,
+              typedAtom.BaseAtom,
+              subscriptAtom,
+              superscriptAtom,
+              typedAtom.UseVerticalLimits);
+        }
+
+        return new BigOperatorAtom(source, atom, subscriptAtom, superscriptAtom);
+      }
+      else
+      {
+        var source = new SourceSpan(value.Source, initialPosition, position - initialPosition);
+        return new ScriptsAtom(source, atom, subscriptAtom, superscriptAtom);
+      }
+    }
+
+    private Atom ConvertCharacter(TexFormula formula, ref int position, SourceSpan source)
+    {
+      var character = source[0];
+      position++;
+      if (IsSymbol(character) && formula.TextStyle != TexUtilities.TextStyleName)
+      {
+        // Character is symbol.
+        var symbolName = symbols.ElementAtOrDefault(character);
+        if (string.IsNullOrEmpty(symbolName))
+          throw new TexParseException($"Unknown character : '{character}'");
+
+        try
+        {
+          return SymbolAtom.GetAtom(symbolName, source);
+        }
+        catch (SymbolNotFoundException e)
+        {
+          throw new TexParseException("The character '"
+                  + character.ToString()
+                  + "' was mapped to an unknown symbol with the name '"
+                  + symbolName + "'!", e);
+        }
+      }
+      else // Character is alpha-numeric or should be rendered as text.
+      {
+        return new CharAtom(source, character, formula.TextStyle);
+      }
+    }
+
+    private static void SkipWhiteSpace(SourceSpan value, ref int position)
+    {
+      while (position < value.Length && IsWhiteSpace(value[position]))
+        position++;
+    }
+  }
 }


### PR DESCRIPTION
Closes #171.

The first commit was cherry-picked from [the commit](https://github.com/Altaxo/Altaxo/commit/60f8ca7b2da9ea057ad4a129ea707f3f31a3746a) [pointed](https://github.com/ForNeVeR/wpf-math/issues/171#issuecomment-449133395) by @lellid.

@lellid, thank you!

**TODO**:
- [x] un-apply the formatting changes
- [x] investigate what's going on with the XML diff (probably the usual CRLF stuff so doesn't matter)
  - _confirmed, the changes are from CRLF to LF, so that's okay_
- [x] add a couple of tests