### PR TITLE
Set DebugType to Full to prevent losing stack traces on .NET Framework

### DIFF
--- a/src/WpfMath.Example/WpfMath.Example.csproj
+++ b/src/WpfMath.Example/WpfMath.Example.csproj
@@ -1,9 +1,10 @@
 ﻿<Project Sdk="Sunburst.NET.Sdk.WPF/1.0.47">
-  <PropertyGroup>
-    <OutputType>WinExe</OutputType>
-    <TargetFramework>net40</TargetFramework>
-  </PropertyGroup>
-  <ItemGroup>
-    <ProjectReference Include="../WpfMath/WpfMath.csproj" />
-  </ItemGroup>
+    <PropertyGroup>
+        <OutputType>WinExe</OutputType>
+        <TargetFramework>net40</TargetFramework>
+        <DebugType>Full</DebugType>
+    </PropertyGroup>
+    <ItemGroup>
+        <ProjectReference Include="../WpfMath/WpfMath.csproj"/>
+    </ItemGroup>
 </Project>

--- a/src/WpfMath.Tests/WpfMath.Tests.fsproj
+++ b/src/WpfMath.Tests/WpfMath.Tests.fsproj
@@ -2,7 +2,7 @@
     <PropertyGroup>
         <TargetFramework>net461</TargetFramework>
         <IsPackable>false</IsPackable>
-        <DebugType>Full</DebugType> <!-- To preserve stack traces, important for ApprovalTests.Net -->
+        <DebugType>Full</DebugType>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="ApprovalTests" Version="3.0.19" />

--- a/src/WpfMath/WpfMath.csproj
+++ b/src/WpfMath/WpfMath.csproj
@@ -1,19 +1,20 @@
 ﻿<Project Sdk="Sunburst.NET.Sdk.WPF/1.0.47">
-  <PropertyGroup>
-    <TargetFramework>net40</TargetFramework>
-    <LangVersion>7.2</LangVersion>
-  </PropertyGroup>
-  <PropertyGroup>
-    <AssemblyTitle>WPF-Math</AssemblyTitle>
-    <Description>.NET library for rendering mathematical formulae using the LaTeX typsetting style, for the WPF framework.</Description>
-    <Copyright>Copyright © Alex Regueiro 2010; Copyright © WPF-Math Contributors 2018</Copyright>
-    <AssemblyVersion>0.6.0</AssemblyVersion>
-  </PropertyGroup>
-  <ItemGroup>
-    <EmbeddedResource Include="Data/*" />
-    <Resource Include="Fonts\cmex10.ttf" />
-    <Resource Include="Fonts\cmmi10.ttf" />
-    <Resource Include="Fonts\cmr10.ttf" />
-    <Resource Include="Fonts\cmsy10.ttf" />
-  </ItemGroup>
+    <PropertyGroup>
+        <TargetFramework>net40</TargetFramework>
+        <LangVersion>7.2</LangVersion>
+        <DebugType>Full</DebugType>
+    </PropertyGroup>
+    <PropertyGroup>
+        <AssemblyTitle>WPF-Math</AssemblyTitle>
+        <Description>.NET library for rendering mathematical formulae using the LaTeX typsetting style, for the WPF framework.</Description>
+        <Copyright>Copyright © Alex Regueiro 2010; Copyright © WPF-Math Contributors 2018</Copyright>
+        <AssemblyVersion>0.6.0</AssemblyVersion>
+    </PropertyGroup>
+    <ItemGroup>
+        <EmbeddedResource Include="Data/*"/>
+        <Resource Include="Fonts\cmex10.ttf"/>
+        <Resource Include="Fonts\cmmi10.ttf"/>
+        <Resource Include="Fonts\cmr10.ttf"/>
+        <Resource Include="Fonts\cmsy10.ttf"/>
+    </ItemGroup>
 </Project>


### PR DESCRIPTION
Otherwise, the code becomes harder to debug on .NET Framework (and we for now only support .NET Framework).