### PR TITLE
VS2019 build compatibility

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,5 @@
-﻿image: Visual Studio 2017
+﻿image:
+    - Visual Studio 2017
+    - Visual Studio 2019
 before_build:
-- nuget restore
+    - nuget restore

--- a/src/WpfMath.Example/WpfMath.Example.csproj
+++ b/src/WpfMath.Example/WpfMath.Example.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Sunburst.NET.Sdk.WPF/1.0.47">
+﻿<Project Sdk="Sunburst.NET.Sdk.WPF.Patched/1.0.49">
     <PropertyGroup>
         <OutputType>WinExe</OutputType>
         <TargetFramework>net40</TargetFramework>

--- a/src/WpfMath/WpfMath.csproj
+++ b/src/WpfMath/WpfMath.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Sunburst.NET.Sdk.WPF/1.0.47">
+﻿<Project Sdk="Sunburst.NET.Sdk.WPF.Patched/1.0.49">
     <PropertyGroup>
         <TargetFramework>net40</TargetFramework>
         <LangVersion>7.2</LangVersion>


### PR DESCRIPTION
This PR closes #193.

I had to [publish an update](https://github.com/SunburstApps/MSBuildSdks/compare/master...ForNeVeR:Sunburst.NET.Sdk.WindowsForms.Patched-v1.0.49) for the custom SDK we use to build WPF stuff with the .NET Core build system.