### PR TITLE
Turn off the deterministic builds for F#

### DIFF
--- a/src/WpfMath.Tests/WpfMath.Tests.fsproj
+++ b/src/WpfMath.Tests/WpfMath.Tests.fsproj
@@ -3,6 +3,7 @@
         <TargetFramework>net461</TargetFramework>
         <IsPackable>false</IsPackable>
         <DebugType>Full</DebugType>
+        <Deterministic>false</Deterministic>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="ApprovalTests" Version="3.0.19" />


### PR DESCRIPTION
Otherwise they were failing on full PDBs, but we need those for Approvals.NET.