### PR TITLE
Migrate to .NET 4.5.2

### DIFF
--- a/src/WpfMath.Example/WpfMath.Example.csproj
+++ b/src/WpfMath.Example/WpfMath.Example.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Sunburst.NET.Sdk.WPF.Patched/1.0.49">
     <PropertyGroup>
         <OutputType>WinExe</OutputType>
-        <TargetFramework>net40</TargetFramework>
+        <TargetFramework>net452</TargetFramework>
         <DebugType>Full</DebugType>
     </PropertyGroup>
     <ItemGroup>

--- a/src/WpfMath/WpfMath.csproj
+++ b/src/WpfMath/WpfMath.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Sunburst.NET.Sdk.WPF.Patched/1.0.49">
     <PropertyGroup>
-        <TargetFramework>net40</TargetFramework>
+        <TargetFramework>net452</TargetFramework>
         <LangVersion>7.2</LangVersion>
         <DebugType>Full</DebugType>
     </PropertyGroup>
@@ -11,10 +11,10 @@
         <AssemblyVersion>0.6.0</AssemblyVersion>
     </PropertyGroup>
     <ItemGroup>
-        <EmbeddedResource Include="Data/*"/>
-        <Resource Include="Fonts\cmex10.ttf"/>
-        <Resource Include="Fonts\cmmi10.ttf"/>
-        <Resource Include="Fonts\cmr10.ttf"/>
-        <Resource Include="Fonts\cmsy10.ttf"/>
+        <EmbeddedResource Include="Data/*" />
+        <Resource Include="Fonts\cmex10.ttf" />
+        <Resource Include="Fonts\cmmi10.ttf" />
+        <Resource Include="Fonts\cmr10.ttf" />
+        <Resource Include="Fonts\cmsy10.ttf" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
Closes #198.

This will allow me to use `IReadOnlyDictionary` where I need to (e.g. useful for #157).

Note that the unit test project have to use .NET 4.6.1 because of the test libraries we use. I wouldn't consider that as an issue though.