### PR TITLE
Initial implementation of parser extensions

### DIFF
--- a/src/WpfMath.Tests/ParserExceptionTests.fs
+++ b/src/WpfMath.Tests/ParserExceptionTests.fs
@@ -1,17 +1,22 @@
 module WpfMath.Tests.ParserExceptionTests
 
+open System
+
 open Xunit
 
+open WpfMath
+open WpfMath.Atoms
 open WpfMath.Exceptions
+open WpfMath.Parsers
 open WpfMath.Tests.Utils
 
 [<Fact>]
-let ``Non-existing delimiter should throw exception`` () =
+let ``Non-existing delimiter should throw exception``() =
     let markup = @"\left x\right)"
     assertParseThrows<TexParseException> markup
 
 [<Fact>]
-let ``\mathrm{} should throw exn`` () =
+let ``\mathrm{} should throw exn``() =
     assertParseThrows<TexParseException> @"\mathrm{}"
 
 [<Fact>]
@@ -21,3 +26,14 @@ let ``\sqrt should throw a TexParseException``() =
 [<Fact>]
 let ``"\sum_ " should throw a TexParseException``() =
     assertParseThrows<TexParseException> @"\sum_ "
+
+[<Fact>]
+let ``Incorrect command parser behavior should be detected``(): unit =
+    let incorrectParser =
+        { new ICommandParser with
+             member __.ProcessCommand _ =
+                 CommandProcessingResult(SpaceAtom(null), 0) }
+    let parserRegistry = Map([| "dummy", incorrectParser |])
+    let parser = TexFormulaParser(parserRegistry)
+    let ex = Assert.Throws<TexParseException>(Action(fun () -> ignore <| parser.Parse("\dummy")))
+    Assert.Contains("NextPosition = 0", ex.Message)

--- a/src/WpfMath/Parsers/CommandParsers.cs
+++ b/src/WpfMath/Parsers/CommandParsers.cs
@@ -1,0 +1,66 @@
+using WpfMath.Atoms;
+using WpfMath.Exceptions;
+
+namespace WpfMath.Parsers
+{
+    /// <summary>A context that will be passed to the command parser.</summary>
+    internal class CommandContext
+    {
+        /// <summary>TeX formula parser that calls the command.</summary>
+        public TexFormulaParser Parser { get; }
+
+        /// <summary>Current formula.</summary>
+        public TexFormula Formula { get; }
+
+        /// <summary>Source of the current formula. Includes both command name and the arguments.</summary>
+        public SourceSpan FormulaSource { get; }
+
+        /// <summary>
+        /// A position inside of source where the command name start. Useful to provide the source information, not for
+        /// the parsing itself.
+        /// </summary>
+        public int CommandNameStartPosition { get; }
+
+        /// <summary>
+        /// A position inside of source where the command arguments start. Should be a parser start position.
+        /// </summary>
+        public int ArgumentsStartPosition { get; }
+
+        public CommandContext(TexFormulaParser parser, TexFormula formula, SourceSpan formulaSource, int commandNameStartPosition, int argumentsStartPosition)
+        {
+            Parser = parser;
+            Formula = formula;
+            FormulaSource = formulaSource;
+            CommandNameStartPosition = commandNameStartPosition;
+            ArgumentsStartPosition = argumentsStartPosition;
+        }
+    }
+
+    internal class CommandProcessingResult
+    {
+        /// <summary>A parsed atom.</summary>
+        public Atom Atom { get; }
+
+        /// <summary>
+        /// A position pointing to the part of the <see cref="CommandContext.FormulaSource"/> where the parsing should
+        /// proceed.
+        /// </summary>
+        public int NextPosition { get; }
+
+        public CommandProcessingResult(Atom atom, int nextPosition)
+        {
+            Atom = atom;
+            NextPosition = nextPosition;
+        }
+    }
+
+    /// <summary>A command parser interface. Inheritors of this class can perform parsing</summary>
+    internal interface ICommandParser
+    {
+        /// <summary>Parsing of the command arguments.</summary>
+        /// <param name="context">The context of the command.</param>
+        /// <returns>The parsing result, never <c>null</c>.</returns>
+        /// <exception cref="TexParseException">Should be thrown on any error.</exception>
+        CommandProcessingResult ProcessCommand(CommandContext context);
+    }
+}

--- a/src/WpfMath/Parsers/CommandParsers.cs
+++ b/src/WpfMath/Parsers/CommandParsers.cs
@@ -9,11 +9,11 @@ namespace WpfMath.Parsers
         /// <summary>TeX formula parser that calls the command.</summary>
         public TexFormulaParser Parser { get; }
 
-        /// <summary>Current formula.</summary>
+        /// <summary>Current formula that is being constructed.</summary>
         public TexFormula Formula { get; }
 
-        /// <summary>Source of the current formula. Includes both command name and the arguments.</summary>
-        public SourceSpan FormulaSource { get; }
+        /// <summary>Source of the current command: includes both the command name and the arguments.</summary>
+        public SourceSpan CommandSource { get; }
 
         /// <summary>
         /// A position inside of source where the command name start. Useful to provide the source information, not for
@@ -26,11 +26,11 @@ namespace WpfMath.Parsers
         /// </summary>
         public int ArgumentsStartPosition { get; }
 
-        public CommandContext(TexFormulaParser parser, TexFormula formula, SourceSpan formulaSource, int commandNameStartPosition, int argumentsStartPosition)
+        public CommandContext(TexFormulaParser parser, TexFormula formula, SourceSpan commandSource, int commandNameStartPosition, int argumentsStartPosition)
         {
             Parser = parser;
             Formula = formula;
-            FormulaSource = formulaSource;
+            CommandSource = commandSource;
             CommandNameStartPosition = commandNameStartPosition;
             ArgumentsStartPosition = argumentsStartPosition;
         }
@@ -42,7 +42,7 @@ namespace WpfMath.Parsers
         public Atom Atom { get; }
 
         /// <summary>
-        /// A position pointing to the part of the <see cref="CommandContext.FormulaSource"/> where the parsing should
+        /// A position pointing to the part of the <see cref="CommandContext.CommandSource"/> where the parsing should
         /// proceed.
         /// </summary>
         public int NextPosition { get; }
@@ -54,7 +54,10 @@ namespace WpfMath.Parsers
         }
     }
 
-    /// <summary>A command parser interface. Inheritors of this class can perform parsing</summary>
+    /// <summary>
+    /// A parser for a particular command that should read the command name and its arguments and produce an
+    /// <see cref="Atom"/>, and also move the parser position towards the end.
+    /// </summary>
     internal interface ICommandParser
     {
         /// <summary>Parsing of the command arguments.</summary>

--- a/src/WpfMath/Parsers/StandardCommands.cs
+++ b/src/WpfMath/Parsers/StandardCommands.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using WpfMath.Atoms;
+
+namespace WpfMath.Parsers
+{
+    internal static class StandardCommands
+    {
+        private class UnderlineCommand : ICommandParser
+        {
+            public CommandProcessingResult ProcessCommand(CommandContext context)
+            {
+                var source = context.FormulaSource;
+                var position = context.ArgumentsStartPosition;
+                var underlineFormula = context.Parser.Parse(
+                    TexFormulaParser.ReadElement(source, ref position),
+                    context.Formula.TextStyle);
+                var start = context.CommandNameStartPosition;
+                var atomSource = source.Segment(start, position - start);
+                var atom = new UnderlinedAtom(atomSource, underlineFormula.RootAtom);
+                return new CommandProcessingResult(atom, position);
+            }
+        }
+
+        public static IReadOnlyDictionary<string, ICommandParser> Dictionary = new Dictionary<string, ICommandParser>
+        {
+            ["underline"] = new UnderlineCommand()
+        };
+    }
+}

--- a/src/WpfMath/Parsers/StandardCommands.cs
+++ b/src/WpfMath/Parsers/StandardCommands.cs
@@ -9,7 +9,7 @@ namespace WpfMath.Parsers
         {
             public CommandProcessingResult ProcessCommand(CommandContext context)
             {
-                var source = context.FormulaSource;
+                var source = context.CommandSource;
                 var position = context.ArgumentsStartPosition;
                 var underlineFormula = context.Parser.Parse(
                     TexFormulaParser.ReadElement(source, ref position),


### PR DESCRIPTION
This is a first step towards #157. It introduces an ability to pass a command parser collection into a `TexFormulaParser` constructor (this mechanism is unused yet, but will be used in #155 soon), and, as an excercise, ports one of our command parsers to the new system.

Other parsers will be ported later in #157. I don't expect anything extraordinary there, but we'll probably be able to share more parts of the parser implementations, and thus remove some code from the `TexFormulaParser`.

Tests will help to make sure there's absolutely no observable difference between the old and the new parser code.