### PR TITLE
`\mathrm{}` shouldn't throw exn

### DIFF
--- a/src/WpfMath.Tests/BoxTests.fs
+++ b/src/WpfMath.Tests/BoxTests.fs
@@ -115,3 +115,11 @@ let wideItemInMatrixBox() =
 [<Fact>]
 let emptyColorbox(): unit =
     verifyBox @"\colorbox{red}{}"
+
+[<Fact>]
+let emptyMathrm(): unit =
+    verifyBox @"\mathrm{}"
+
+[<Fact>]
+let emptyCommandText(): unit =
+    verifyBox @"\text{}"

--- a/src/WpfMath.Tests/ParserExceptionTests.fs
+++ b/src/WpfMath.Tests/ParserExceptionTests.fs
@@ -16,10 +16,6 @@ let ``Non-existing delimiter should throw exception``() =
     assertParseThrows<TexParseException> markup
 
 [<Fact>]
-let ``\mathrm{} should throw exn``() =
-    assertParseThrows<TexParseException> @"\mathrm{}"
-
-[<Fact>]
 let ``\sqrt should throw a TexParseException``() =
     assertParseThrows<TexParseException> @"\sqrt"
 

--- a/src/WpfMath.Tests/TestResults/BoxTests.emptyCommandText.approved.txt
+++ b/src/WpfMath.Tests/TestResults/BoxTests.emptyCommandText.approved.txt
@@ -1,0 +1,18 @@
+﻿{
+  "Children": [],
+  "Source": {
+    "Start": 1,
+    "End": 7,
+    "Length": 6,
+    "Source": "\\text{}"
+  },
+  "Foreground": null,
+  "Background": null,
+  "TotalHeight": 0.0,
+  "TotalWidth": 0.0,
+  "Italic": 0.0,
+  "Width": 0.0,
+  "Height": 0.0,
+  "Depth": 0.0,
+  "Shift": 0.0
+}

--- a/src/WpfMath.Tests/TestResults/BoxTests.emptyMathrm.approved.txt
+++ b/src/WpfMath.Tests/TestResults/BoxTests.emptyMathrm.approved.txt
@@ -1,0 +1,18 @@
+﻿{
+  "Children": [],
+  "Source": {
+    "Start": 1,
+    "End": 9,
+    "Length": 8,
+    "Source": "\\mathrm{}"
+  },
+  "Foreground": null,
+  "Background": null,
+  "TotalHeight": 0.0,
+  "TotalWidth": 0.0,
+  "Italic": 0.0,
+  "Width": 0.0,
+  "Height": 0.0,
+  "Depth": 0.0,
+  "Shift": 0.0
+}

--- a/src/WpfMath/TexFormula.cs
+++ b/src/WpfMath/TexFormula.cs
@@ -33,7 +33,6 @@ namespace WpfMath
         public void Add(TexFormula formula, SourceSpan source = null)
         {
             Debug.Assert(formula != null);
-            Debug.Assert(formula.RootAtom != null);
 
             this.Add(
                 formula.RootAtom is RowAtom
@@ -50,7 +49,6 @@ namespace WpfMath
         /// <param name="rowSource">The source that will be set for the resulting row atom.</param>
         internal void Add(Atom atom, SourceSpan rowSource)
         {
-            Debug.Assert(atom != null);
             if (this.RootAtom == null)
             {
                 this.RootAtom = atom;
@@ -91,10 +89,7 @@ namespace WpfMath
 
         internal Box CreateBox(TexEnvironment environment)
         {
-            if (this.RootAtom == null)
-                return StrutBox.Empty;
-            else
-                return this.RootAtom.CreateBox(environment);
+            return this.RootAtom?.CreateBox(environment) ?? StrutBox.Empty;
         }
 
         internal static SystemFont GetSystemFont(string fontName, double size)

--- a/src/WpfMath/TexFormula.cs
+++ b/src/WpfMath/TexFormula.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Windows.Media;
@@ -33,6 +33,7 @@ namespace WpfMath
         public void Add(TexFormula formula, SourceSpan source = null)
         {
             Debug.Assert(formula != null);
+            Debug.Assert(formula.RootAtom != null);
 
             this.Add(
                 formula.RootAtom is RowAtom

--- a/src/WpfMath/TexFormula.cs
+++ b/src/WpfMath/TexFormula.cs
@@ -89,7 +89,10 @@ namespace WpfMath
 
         internal Box CreateBox(TexEnvironment environment)
         {
-            return this.RootAtom?.CreateBox(environment) ?? StrutBox.Empty;
+            if (this.RootAtom == null)
+                return StrutBox.Empty;
+            else
+                return this.RootAtom.CreateBox(environment);
         }
 
         internal static SystemFont GetSystemFont(string fontName, double size)

--- a/src/WpfMath/TexFormulaParser.cs
+++ b/src/WpfMath/TexFormulaParser.cs
@@ -576,9 +576,6 @@ namespace WpfMath
                     ? ConvertRawText(ReadElement(value, ref position), command)
                     : Parse(ReadElement(value, ref position), command, environment.CreateChildEnvironment());
 
-                if (styledFormula.RootAtom == null)
-                    throw new TexParseException("Styled text can't be empty!");
-
                 var atom = AttachScripts(formula, value, ref position, styledFormula.RootAtom, true, environment);
                 var source = new SourceSpan(formulaSource.Source, formulaSource.Start, position);
                 formula.Add(atom, source);

--- a/src/WpfMath/TexFormulaParser.cs
+++ b/src/WpfMath/TexFormulaParser.cs
@@ -572,13 +572,15 @@ namespace WpfMath
                 // Text style was found.
                 SkipWhiteSpace(value, ref position);
 
-                var styledFormula = command == TexUtilities.TextStyleName
-                    ? ConvertRawText(ReadElement(value, ref position), command)
-                    : Parse(ReadElement(value, ref position), command, environment.CreateChildEnvironment());
+                var remainingString = ReadElement(value, ref position);
+                var remaining = command == TexUtilities.TextStyleName
+                    ? ConvertRawText(remainingString, command)
+                    : Parse(remainingString, command, environment.CreateChildEnvironment());
 
-                var atom = AttachScripts(formula, value, ref position, styledFormula.RootAtom, true, environment);
-                var source = new SourceSpan(formulaSource.Source, formulaSource.Start, position);
-                formula.Add(atom, source);
+                var source = value.Segment(start, position - start);
+                var styledAtom = new StyledAtom(source, remaining.RootAtom, null, null);
+                var commandAtom = AttachScripts(formula, value, ref position, styledAtom, true, environment);
+                formula.Add(commandAtom, source);
             }
             else if (embeddedCommands.Contains(command)
                  || environment.AvailableCommands.ContainsKey(command)

--- a/src/WpfMath/TexFormulaParser.cs
+++ b/src/WpfMath/TexFormulaParser.cs
@@ -578,8 +578,8 @@ namespace WpfMath
                     : Parse(remainingString, command, environment.CreateChildEnvironment());
 
                 var source = value.Segment(start, position - start);
-                var styledAtom = new StyledAtom(source, remaining.RootAtom, null, null);
-                var commandAtom = AttachScripts(formula, value, ref position, styledAtom, true, environment);
+                var atom = new RowAtom(source, remaining.RootAtom);
+                var commandAtom = AttachScripts(formula, value, ref position, atom, true, environment);
                 formula.Add(commandAtom, source);
             }
             else if (embeddedCommands.Contains(command)

--- a/src/WpfMath/TexFormulaParser.cs
+++ b/src/WpfMath/TexFormulaParser.cs
@@ -572,13 +572,12 @@ namespace WpfMath
                 // Text style was found.
                 SkipWhiteSpace(value, ref position);
 
-                var remainingString = ReadElement(value, ref position);
-                var remaining = command == TexUtilities.TextStyleName
-                    ? ConvertRawText(remainingString, command)
-                    : Parse(remainingString, command, environment.CreateChildEnvironment());
+                var styledFormula = command == TexUtilities.TextStyleName
+                    ? ConvertRawText(ReadElement(value, ref position), command)
+                    : Parse(ReadElement(value, ref position), command, environment.CreateChildEnvironment());
 
                 var source = value.Segment(start, position - start);
-                var atom = new RowAtom(source, remaining.RootAtom);
+                var atom = styledFormula.RootAtom ?? new NullAtom(source);
                 var commandAtom = AttachScripts(formula, value, ref position, atom, true, environment);
                 formula.Add(commandAtom, source);
             }


### PR DESCRIPTION
Change state "\mathrm{} should throw exn" to "\mathrm{} shouldn't throw exn"