### PR TITLE
Delete FSharp.Core from the project file (#210)

### DIFF
--- a/src/WpfMath.Tests/WpfMath.Tests.fsproj
+++ b/src/WpfMath.Tests/WpfMath.Tests.fsproj
@@ -8,7 +8,6 @@
     <ItemGroup>
         <PackageReference Include="ApprovalTests" Version="3.0.19" />
         <PackageReference Include="Foq" Version="1.7.3" />
-        <PackageReference Include="FSharp.Core" Version="4.2.3" />
         <PackageReference Include="FSharp.Core.Fluent-4.0" Version="1.0.0.6" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
         <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />


### PR DESCRIPTION
I've found that the FSharp.Core version is for some reason hardcoded in our current `.fsproj`, and it causes compilation troubles in VS.

FSharp.Core is implicitly added by SDK anyways, so I see no reason to keep this reference inplace.

Closes #210.