### PR TITLE
Destroy the BOM

### DIFF
--- a/WpfMath.sln
+++ b/WpfMath.sln
@@ -1,4 +1,4 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
 VisualStudioVersion = 14.0.25420.1

--- a/WpfMath.sln
+++ b/WpfMath.sln
@@ -34,6 +34,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "scripts", "scripts", "{BE4BA1DB-B8BC-4718-AA9D-23B0191C9323}"
 ProjectSection(SolutionItems) = preProject
 	scripts\approve-all.ps1 = scripts\approve-all.ps1
+	scripts\verify-encoding.ps1 = scripts\verify-encoding.ps1
 EndProjectSection
 EndProject
 Global

--- a/WpfMath.sln
+++ b/WpfMath.sln
@@ -22,7 +22,6 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{39669369-C4F6-4AC6-9D35-B4B6086FF172}"
 	ProjectSection(SolutionItems) = preProject
 		docs\example-screenshot.png = docs\example-screenshot.png
-		docs\JMathTeX-license.txt = docs\JMathTeX-license.txt
 		docs\colors.md = docs\colors.md
 		docs\licensing-history.md = docs\licensing-history.md
 		docs\blurred-text-issue.md = docs\blurred-text-issue.md
@@ -31,6 +30,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{39669369-C
 		docs\matrices.md = docs\matrices.md
 		docs\prepare-font.md = docs\prepare-font.md
 	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "scripts", "scripts", "{BE4BA1DB-B8BC-4718-AA9D-23B0191C9323}"
+ProjectSection(SolutionItems) = preProject
+	scripts\approve-all.ps1 = scripts\approve-all.ps1
+EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -56,5 +60,6 @@ Global
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{39669369-C4F6-4AC6-9D35-B4B6086FF172} = {D9341AA3-BF7C-4CC1-8E11-82258967B82F}
+		{BE4BA1DB-B8BC-4718-AA9D-23B0191C9323} = {D9341AA3-BF7C-4CC1-8E11-82258967B82F}
 	EndGlobalSection
 EndGlobal

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,10 @@
 image:
     - Visual Studio 2019
+before_build:
+    - pwsh: ./scripts/verify-encoding.ps1
 build_script:
     - dotnet build
 after_build:
-    - pwsh: ./scripts/verify-encoding.ps1
     - dotnet pack
 test_script:
     - dotnet test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-﻿image:
+image:
     - Visual Studio 2019
 build_script:
     - dotnet build

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,7 @@
 build_script:
     - dotnet build
 after_build:
+    - pwsh: ./scripts/verify-encoding.ps1
     - dotnet pack
 test_script:
     - dotnet test

--- a/scripts/verify-encoding.ps1
+++ b/scripts/verify-encoding.ps1
@@ -1,0 +1,51 @@
+<#
+.SYNOPSIS
+    This script will verify that there's no UTF-8 BOM in the files inside of the project.
+#>
+param (
+    $SourceRoot = "$PSScriptRoot/..",
+    $Autofix = $false
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# For PowerShell to process git ls-tree output properly we need to set up the output encoding:
+[Console]::OutputEncoding = [Text.Encoding]::UTF8
+
+$allFiles = git -c core.quotepath=off ls-tree -r HEAD --name-only
+Write-Output "Total files in the repository: $($allFiles.Length)"
+
+# https://stackoverflow.com/questions/6119956/how-to-determine-if-git-handles-a-file-as-binary-or-as-text#comment15281840_6134127
+$nullHash = '4b825dc642cb6eb9a060e54bf8d69288fbee4904'
+$textFiles = git -c core.quotepath=off diff --numstat $nullHash HEAD -- @allFiles |
+    Where-Object { -not $_.StartsWith('-') } |
+    ForEach-Object { [Regex]::Unescape($_.Split("`t", 3)[2]) }
+Write-Output "Text files in the repository: $($textFiles.Length)"
+
+$bom = @(0xEF, 0xBB, 0xBF)
+$errors = @()
+
+try {
+    Push-Location $SourceRoot
+    foreach ($file in $textFiles) {
+        $fullPath = Resolve-Path -LiteralPath $file
+        $bytes = [IO.File]::ReadAllBytes($fullPath) | Select-Object -First $bom.Length
+        $bytesEqualsBom = @(Compare-Object $bytes $bom -SyncWindow 0).Length -eq 0
+        if ($bytesEqualsBom) {
+            $errors += @($file)
+        }
+
+        if ($Autofix) {
+            $fullContent = [IO.File]::ReadAllBytes($fullPath)
+            $newContent = $fullContent | Select-Object -Skip $bom.Length
+            Set-Content $file $newContent
+        }
+    }
+
+    if ($errors.Length -and -not $Autofix) {
+        throw "The follwing $($errors.Length) files have UTF-8 BOM:`n" + ($errors -join "`n")
+    }
+} finally {
+    Pop-Location
+}

--- a/src/WpfMath.Example/App.xaml
+++ b/src/WpfMath.Example/App.xaml
@@ -1,4 +1,4 @@
-﻿<Application x:Class="WpfMath.Example.App"
+<Application x:Class="WpfMath.Example.App"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              StartupUri="MainWindow.xaml"

--- a/src/WpfMath.Example/App.xaml.cs
+++ b/src/WpfMath.Example/App.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Configuration;
 using System.Data;

--- a/src/WpfMath.Tests/ApprovalTestUtils.fs
+++ b/src/WpfMath.Tests/ApprovalTestUtils.fs
@@ -27,7 +27,7 @@ type private BomlessFileWriter(data: string, ?extensionWithoutDot: string) =
 [<assembly: UseReporter(typeof<DiffReporter>)>]
 [<assembly: UseApprovalSubdirectory("TestResults")>]
 do
-    WriterFactory.TextWriterCreator <- Func<_, _>(fun data -> upcast BomlessFileWriter(data))
+    WriterFactory.TextWriterCreator <- Func<_, _>(fun data -> upcast BomlessFileWriter data)
     WriterFactory.TextWriterWithExtensionCreator <- Func<_, _, _>(fun data extensionWithoutDot ->
         upcast BomlessFileWriter(data, extensionWithoutDot)
     )

--- a/src/WpfMath.Tests/TestResults/BoxTests.casesBox.approved.txt
+++ b/src/WpfMath.Tests/TestResults/BoxTests.casesBox.approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "Children": [
     {
       "Character": {

--- a/src/WpfMath.Tests/TestResults/BoxTests.emptyColorRed.approved.txt
+++ b/src/WpfMath.Tests/TestResults/BoxTests.emptyColorRed.approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "Children": [],
   "Source": {
     "Start": 1,

--- a/src/WpfMath.Tests/TestResults/BoxTests.emptyColorbox.approved.txt
+++ b/src/WpfMath.Tests/TestResults/BoxTests.emptyColorbox.approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "Children": [],
   "Source": {
     "Start": 1,

--- a/src/WpfMath.Tests/TestResults/BoxTests.emptyCommandText.approved.txt
+++ b/src/WpfMath.Tests/TestResults/BoxTests.emptyCommandText.approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "Children": [],
   "Source": {
     "Start": 1,

--- a/src/WpfMath.Tests/TestResults/BoxTests.emptyMathrm.approved.txt
+++ b/src/WpfMath.Tests/TestResults/BoxTests.emptyMathrm.approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "Children": [],
   "Source": {
     "Start": 1,

--- a/src/WpfMath.Tests/TestResults/BoxTests.nestedMatrixBox.approved.txt
+++ b/src/WpfMath.Tests/TestResults/BoxTests.nestedMatrixBox.approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "Children": [
     {
       "Children": [

--- a/src/WpfMath.Tests/TestResults/BoxTests.simpleMatrixBox.approved.txt
+++ b/src/WpfMath.Tests/TestResults/BoxTests.simpleMatrixBox.approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "Children": [
     {
       "Character": {

--- a/src/WpfMath.Tests/TestResults/BoxTests.wideItemInMatrixBox.approved.txt
+++ b/src/WpfMath.Tests/TestResults/BoxTests.wideItemInMatrixBox.approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "Children": [
     {
       "Character": {

--- a/src/WpfMath.Tests/TestResults/ParserTests.2+2.approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.2+2.approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "PreviousAtom": null,

--- a/src/WpfMath.Tests/TestResults/ParserTests.bigMatrixExpression.approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.bigMatrixExpression.approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "PreviousAtom": null,

--- a/src/WpfMath.Tests/TestResults/ParserTests.binom.( 2 x123).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.binom.( 2 x123).approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "PreviousAtom": null,

--- a/src/WpfMath.Tests/TestResults/ParserTests.binom.( 2(x)123).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.binom.( 2(x)123).approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "PreviousAtom": null,

--- a/src/WpfMath.Tests/TestResults/ParserTests.binom.((2)(x)123).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.binom.((2)(x)123).approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "PreviousAtom": null,

--- a/src/WpfMath.Tests/TestResults/ParserTests.binom.((2)x123).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.binom.((2)x123).approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "PreviousAtom": null,

--- a/src/WpfMath.Tests/TestResults/ParserTests.binom.(2 (x)123).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.binom.(2 (x)123).approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "PreviousAtom": null,

--- a/src/WpfMath.Tests/TestResults/ParserTests.binom.(2(x)123).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.binom.(2(x)123).approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "PreviousAtom": null,

--- a/src/WpfMath.Tests/TestResults/ParserTests.binom.(2x123).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.binom.(2x123).approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "PreviousAtom": null,

--- a/src/WpfMath.Tests/TestResults/ParserTests.color.((red) (1)123).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.color.((red) (1)123).approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "PreviousAtom": null,

--- a/src/WpfMath.Tests/TestResults/ParserTests.color.((red) 1123).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.color.((red) 1123).approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "PreviousAtom": null,

--- a/src/WpfMath.Tests/TestResults/ParserTests.color.((red)(1)123).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.color.((red)(1)123).approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "PreviousAtom": null,

--- a/src/WpfMath.Tests/TestResults/ParserTests.color.((red)1123).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.color.((red)1123).approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "PreviousAtom": null,

--- a/src/WpfMath.Tests/TestResults/ParserTests.colorModels.(color (red) x).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.colorModels.(color (red) x).approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "RowAtom": {

--- a/src/WpfMath.Tests/TestResults/ParserTests.colorModels.(color [HTML] (abcdef) x).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.colorModels.(color [HTML] (abcdef) x).approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "RowAtom": {

--- a/src/WpfMath.Tests/TestResults/ParserTests.colorModels.(color [RGB] (128, 128, 128) x).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.colorModels.(color [RGB] (128, 128, 128) x).approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "RowAtom": {

--- a/src/WpfMath.Tests/TestResults/ParserTests.colorModels.(color [] (red) x).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.colorModels.(color [] (red) x).approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "RowAtom": {

--- a/src/WpfMath.Tests/TestResults/ParserTests.colorModels.(color [cmyk] (0.5, 0.5, 0.5, 0.5) x).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.colorModels.(color [cmyk] (0.5, 0.5, 0.5, 0.5) x).approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "RowAtom": {

--- a/src/WpfMath.Tests/TestResults/ParserTests.colorModels.(color [gray] (0.5) x).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.colorModels.(color [gray] (0.5) x).approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "RowAtom": {

--- a/src/WpfMath.Tests/TestResults/ParserTests.colorModels.(color [rgb] (0.5, 0.5, 0.5) x).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.colorModels.(color [rgb] (0.5, 0.5, 0.5) x).approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "RowAtom": {

--- a/src/WpfMath.Tests/TestResults/ParserTests.colorModels.(colorbox (red) x).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.colorModels.(colorbox (red) x).approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "RowAtom": {

--- a/src/WpfMath.Tests/TestResults/ParserTests.colorModels.(colorbox [HTML] (abcdef) x).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.colorModels.(colorbox [HTML] (abcdef) x).approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "RowAtom": {

--- a/src/WpfMath.Tests/TestResults/ParserTests.colorModels.(colorbox [RGB] (128, 128, 128) x).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.colorModels.(colorbox [RGB] (128, 128, 128) x).approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "RowAtom": {

--- a/src/WpfMath.Tests/TestResults/ParserTests.colorModels.(colorbox [] (red) x).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.colorModels.(colorbox [] (red) x).approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "RowAtom": {

--- a/src/WpfMath.Tests/TestResults/ParserTests.colorModels.(colorbox [cmyk] (0.5, 0.5, 0.5, 0.5) x).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.colorModels.(colorbox [cmyk] (0.5, 0.5, 0.5, 0.5) x).approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "RowAtom": {

--- a/src/WpfMath.Tests/TestResults/ParserTests.colorModels.(colorbox [gray] (0.5) x).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.colorModels.(colorbox [gray] (0.5) x).approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "RowAtom": {

--- a/src/WpfMath.Tests/TestResults/ParserTests.colorModels.(colorbox [rgb] (0.5, 0.5, 0.5) x).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.colorModels.(colorbox [rgb] (0.5, 0.5, 0.5) x).approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "RowAtom": {

--- a/src/WpfMath.Tests/TestResults/ParserTests.colorModelsWithOpacity.(color (red, 0.1) x).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.colorModelsWithOpacity.(color (red, 0.1) x).approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "RowAtom": {

--- a/src/WpfMath.Tests/TestResults/ParserTests.colorModelsWithOpacity.(color [ARGB] (25, 128, 128, 128) x).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.colorModelsWithOpacity.(color [ARGB] (25, 128, 128, 128) x).approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "RowAtom": {

--- a/src/WpfMath.Tests/TestResults/ParserTests.colorModelsWithOpacity.(color [HTML] (abcdef19) x).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.colorModelsWithOpacity.(color [HTML] (abcdef19) x).approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "RowAtom": {

--- a/src/WpfMath.Tests/TestResults/ParserTests.colorModelsWithOpacity.(color [RGBA] (128, 128, 128, 25) x).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.colorModelsWithOpacity.(color [RGBA] (128, 128, 128, 25) x).approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "RowAtom": {

--- a/src/WpfMath.Tests/TestResults/ParserTests.colorModelsWithOpacity.(color [] (red, 0.1) x).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.colorModelsWithOpacity.(color [] (red, 0.1) x).approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "RowAtom": {

--- a/src/WpfMath.Tests/TestResults/ParserTests.colorModelsWithOpacity.(color [argb] (0.1, 0.5, 0.5, 0.5) x).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.colorModelsWithOpacity.(color [argb] (0.1, 0.5, 0.5, 0.5) x).approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "RowAtom": {

--- a/src/WpfMath.Tests/TestResults/ParserTests.colorModelsWithOpacity.(color [cmyk] (0.5, 0.5, 0.5, 0.5, 0.1) x).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.colorModelsWithOpacity.(color [cmyk] (0.5, 0.5, 0.5, 0.5, 0.1) x).approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "RowAtom": {

--- a/src/WpfMath.Tests/TestResults/ParserTests.colorModelsWithOpacity.(color [gray] (0.5, 0.1) x).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.colorModelsWithOpacity.(color [gray] (0.5, 0.1) x).approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "RowAtom": {

--- a/src/WpfMath.Tests/TestResults/ParserTests.colorModelsWithOpacity.(color [rgba] (0.5, 0.5, 0.5, 0.1) x).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.colorModelsWithOpacity.(color [rgba] (0.5, 0.5, 0.5, 0.1) x).approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "RowAtom": {

--- a/src/WpfMath.Tests/TestResults/ParserTests.colorModelsWithOpacity.(colorbox (red, 0.1) x).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.colorModelsWithOpacity.(colorbox (red, 0.1) x).approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "RowAtom": {

--- a/src/WpfMath.Tests/TestResults/ParserTests.colorModelsWithOpacity.(colorbox [ARGB] (25, 128, 128, 128) x).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.colorModelsWithOpacity.(colorbox [ARGB] (25, 128, 128, 128) x).approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "RowAtom": {

--- a/src/WpfMath.Tests/TestResults/ParserTests.colorModelsWithOpacity.(colorbox [HTML] (abcdef19) x).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.colorModelsWithOpacity.(colorbox [HTML] (abcdef19) x).approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "RowAtom": {

--- a/src/WpfMath.Tests/TestResults/ParserTests.colorModelsWithOpacity.(colorbox [RGBA] (128, 128, 128, 25) x).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.colorModelsWithOpacity.(colorbox [RGBA] (128, 128, 128, 25) x).approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "RowAtom": {

--- a/src/WpfMath.Tests/TestResults/ParserTests.colorModelsWithOpacity.(colorbox [] (red, 0.1) x).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.colorModelsWithOpacity.(colorbox [] (red, 0.1) x).approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "RowAtom": {

--- a/src/WpfMath.Tests/TestResults/ParserTests.colorModelsWithOpacity.(colorbox [argb] (0.1, 0.5, 0.5, 0.5) x).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.colorModelsWithOpacity.(colorbox [argb] (0.1, 0.5, 0.5, 0.5) x).approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "RowAtom": {

--- a/src/WpfMath.Tests/TestResults/ParserTests.colorModelsWithOpacity.(colorbox [cmyk] (0.5, 0.5, 0.5, 0.5, 0.1) x).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.colorModelsWithOpacity.(colorbox [cmyk] (0.5, 0.5, 0.5, 0.5, 0.1) x).approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "RowAtom": {

--- a/src/WpfMath.Tests/TestResults/ParserTests.colorModelsWithOpacity.(colorbox [gray] (0.5, 0.1) x).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.colorModelsWithOpacity.(colorbox [gray] (0.5, 0.1) x).approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "RowAtom": {

--- a/src/WpfMath.Tests/TestResults/ParserTests.colorModelsWithOpacity.(colorbox [rgba] (0.5, 0.5, 0.5, 0.1) x).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.colorModelsWithOpacity.(colorbox [rgba] (0.5, 0.5, 0.5, 0.1) x).approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "RowAtom": {

--- a/src/WpfMath.Tests/TestResults/ParserTests.colorbox.((red) (1)123).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.colorbox.((red) (1)123).approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "PreviousAtom": null,

--- a/src/WpfMath.Tests/TestResults/ParserTests.colorbox.((red) 1123).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.colorbox.((red) 1123).approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "PreviousAtom": null,

--- a/src/WpfMath.Tests/TestResults/ParserTests.colorbox.((red)(1)123).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.colorbox.((red)(1)123).approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "PreviousAtom": null,

--- a/src/WpfMath.Tests/TestResults/ParserTests.colorbox.((red)1123).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.colorbox.((red)1123).approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "PreviousAtom": null,

--- a/src/WpfMath.Tests/TestResults/ParserTests.commandsInText.approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.commandsInText.approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "PreviousAtom": null,

--- a/src/WpfMath.Tests/TestResults/ParserTests.complexMathrm.approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.complexMathrm.approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "PreviousAtom": null,

--- a/src/WpfMath.Tests/TestResults/ParserTests.cyrillicText.approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.cyrillicText.approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "PreviousAtom": null,

--- a/src/WpfMath.Tests/TestResults/ParserTests.delimiterWithScripts.approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.delimiterWithScripts.approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "BaseAtom": {

--- a/src/WpfMath.Tests/TestResults/ParserTests.delimiters.((,)).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.delimiters.((,)).approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "BaseAtom": {

--- a/src/WpfMath.Tests/TestResults/ParserTests.delimiters.(backslash,backslash).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.delimiters.(backslash,backslash).approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "BaseAtom": {

--- a/src/WpfMath.Tests/TestResults/ParserTests.delimiters.(langle,rangle).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.delimiters.(langle,rangle).approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "BaseAtom": {

--- a/src/WpfMath.Tests/TestResults/ParserTests.delimiters.(lbrace,rbrace).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.delimiters.(lbrace,rbrace).approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "BaseAtom": {

--- a/src/WpfMath.Tests/TestResults/ParserTests.delimiters.(lbrack,rbrack).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.delimiters.(lbrack,rbrack).approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "BaseAtom": {

--- a/src/WpfMath.Tests/TestResults/ParserTests.delimiters.(vert,vert).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.delimiters.(vert,vert).approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "BaseAtom": {

--- a/src/WpfMath.Tests/TestResults/ParserTests.emptyCurlyBraces.approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.emptyCurlyBraces.approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "Atom": {

--- a/src/WpfMath.Tests/TestResults/ParserTests.emptyDelimiters.(((,.,false,true)).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.emptyDelimiters.(((,.,false,true)).approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "BaseAtom": {

--- a/src/WpfMath.Tests/TestResults/ParserTests.emptyDelimiters.((.,),true,false)).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.emptyDelimiters.((.,),true,false)).approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "BaseAtom": {

--- a/src/WpfMath.Tests/TestResults/ParserTests.expressionAfterBraces.approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.expressionAfterBraces.approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "PreviousAtom": null,

--- a/src/WpfMath.Tests/TestResults/ParserTests.expressionInBraces.approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.expressionInBraces.approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "BaseAtom": {

--- a/src/WpfMath.Tests/TestResults/ParserTests.frac.( 2 x123).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.frac.( 2 x123).approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "PreviousAtom": null,

--- a/src/WpfMath.Tests/TestResults/ParserTests.frac.( 2(x)123).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.frac.( 2(x)123).approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "PreviousAtom": null,

--- a/src/WpfMath.Tests/TestResults/ParserTests.frac.((2)(x)123).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.frac.((2)(x)123).approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "PreviousAtom": null,

--- a/src/WpfMath.Tests/TestResults/ParserTests.frac.((2)x123).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.frac.((2)x123).approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "PreviousAtom": null,

--- a/src/WpfMath.Tests/TestResults/ParserTests.frac.(2 (x)123).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.frac.(2 (x)123).approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "PreviousAtom": null,

--- a/src/WpfMath.Tests/TestResults/ParserTests.frac.(2(x)123).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.frac.(2(x)123).approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "PreviousAtom": null,

--- a/src/WpfMath.Tests/TestResults/ParserTests.frac.(2x123).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.frac.(2x123).approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "PreviousAtom": null,

--- a/src/WpfMath.Tests/TestResults/ParserTests.hat.approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.hat.approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "Atom": {

--- a/src/WpfMath.Tests/TestResults/ParserTests.intF.approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.intF.approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "PreviousAtom": null,

--- a/src/WpfMath.Tests/TestResults/ParserTests.integral.approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.integral.approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "BaseAtom": {

--- a/src/WpfMath.Tests/TestResults/ParserTests.lim.approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.lim.approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "PreviousAtom": null,

--- a/src/WpfMath.Tests/TestResults/ParserTests.limInCurlyBraces.approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.limInCurlyBraces.approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "PreviousAtom": null,

--- a/src/WpfMath.Tests/TestResults/ParserTests.mathcal.approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.mathcal.approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "PreviousAtom": null,

--- a/src/WpfMath.Tests/TestResults/ParserTests.mathit.approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.mathit.approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "PreviousAtom": null,

--- a/src/WpfMath.Tests/TestResults/ParserTests.mathrm.approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.mathrm.approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "PreviousAtom": null,

--- a/src/WpfMath.Tests/TestResults/ParserTests.matrixExpression.approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.matrixExpression.approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "PreviousAtom": null,

--- a/src/WpfMath.Tests/TestResults/ParserTests.nestedMatrix.approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.nestedMatrix.approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "MatrixCells": [

--- a/src/WpfMath.Tests/TestResults/ParserTests.overline.( (1)123).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.overline.( (1)123).approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "PreviousAtom": null,

--- a/src/WpfMath.Tests/TestResults/ParserTests.overline.( 1123).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.overline.( 1123).approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "PreviousAtom": null,

--- a/src/WpfMath.Tests/TestResults/ParserTests.overline.((1)123).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.overline.((1)123).approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "PreviousAtom": null,

--- a/src/WpfMath.Tests/TestResults/ParserTests.overline.(1123).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.overline.(1123).approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "PreviousAtom": null,

--- a/src/WpfMath.Tests/TestResults/ParserTests.piecewiseDefinedFunction.approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.piecewiseDefinedFunction.approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "PreviousAtom": null,

--- a/src/WpfMath.Tests/TestResults/ParserTests.scripts.(x ↑ (y) _ (z)).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.scripts.(x ↑ (y) _ (z)).approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "BaseAtom": {

--- a/src/WpfMath.Tests/TestResults/ParserTests.scripts.(x↑(y)_(z)).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.scripts.(x↑(y)_(z)).approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "BaseAtom": {

--- a/src/WpfMath.Tests/TestResults/ParserTests.scripts.(x↑(y)_z).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.scripts.(x↑(y)_z).approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "BaseAtom": {

--- a/src/WpfMath.Tests/TestResults/ParserTests.scripts.(x↑y_ z).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.scripts.(x↑y_ z).approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "BaseAtom": {

--- a/src/WpfMath.Tests/TestResults/ParserTests.scripts.(x↑y_(z)).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.scripts.(x↑y_(z)).approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "BaseAtom": {

--- a/src/WpfMath.Tests/TestResults/ParserTests.scripts.(x↑y_z).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.scripts.(x↑y_z).approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "BaseAtom": {

--- a/src/WpfMath.Tests/TestResults/ParserTests.simpleCases.approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.simpleCases.approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "BaseAtom": {

--- a/src/WpfMath.Tests/TestResults/ParserTests.simpleMatrix.approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.simpleMatrix.approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "MatrixCells": [

--- a/src/WpfMath.Tests/TestResults/ParserTests.sin.approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.sin.approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "PreviousAtom": null,

--- a/src/WpfMath.Tests/TestResults/ParserTests.spacesInText.approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.spacesInText.approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "PreviousAtom": null,

--- a/src/WpfMath.Tests/TestResults/ParserTests.sqrt.( (1)123).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.sqrt.( (1)123).approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "PreviousAtom": null,

--- a/src/WpfMath.Tests/TestResults/ParserTests.sqrt.( 1123).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.sqrt.( 1123).approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "PreviousAtom": null,

--- a/src/WpfMath.Tests/TestResults/ParserTests.sqrt.((1)123).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.sqrt.((1)123).approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "PreviousAtom": null,

--- a/src/WpfMath.Tests/TestResults/ParserTests.sqrt.(1123).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.sqrt.(1123).approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "PreviousAtom": null,

--- a/src/WpfMath.Tests/TestResults/ParserTests.sqrtWithOptArgument.( [ 2](1)123).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.sqrtWithOptArgument.( [ 2](1)123).approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "PreviousAtom": null,

--- a/src/WpfMath.Tests/TestResults/ParserTests.sqrtWithOptArgument.( [2]1123).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.sqrtWithOptArgument.( [2]1123).approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "PreviousAtom": null,

--- a/src/WpfMath.Tests/TestResults/ParserTests.sqrtWithOptArgument.([ 2 ] (1)123).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.sqrtWithOptArgument.([ 2 ] (1)123).approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "PreviousAtom": null,

--- a/src/WpfMath.Tests/TestResults/ParserTests.sqrtWithOptArgument.([2 ] 1123).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.sqrtWithOptArgument.([2 ] 1123).approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "PreviousAtom": null,

--- a/src/WpfMath.Tests/TestResults/ParserTests.textArgumentParsing.( (1)123).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.textArgumentParsing.( (1)123).approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "PreviousAtom": null,

--- a/src/WpfMath.Tests/TestResults/ParserTests.textArgumentParsing.( 1123).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.textArgumentParsing.( 1123).approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "PreviousAtom": null,

--- a/src/WpfMath.Tests/TestResults/ParserTests.textCommand.approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.textCommand.approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "PreviousAtom": null,

--- a/src/WpfMath.Tests/TestResults/ParserTests.textWithExpression.approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.textWithExpression.approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "PreviousAtom": null,

--- a/src/WpfMath.Tests/TestResults/ParserTests.underline.( (1)123).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.underline.( (1)123).approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "PreviousAtom": null,

--- a/src/WpfMath.Tests/TestResults/ParserTests.underline.( 1123).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.underline.( 1123).approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "PreviousAtom": null,

--- a/src/WpfMath.Tests/TestResults/ParserTests.underline.((1)123).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.underline.((1)123).approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "PreviousAtom": null,

--- a/src/WpfMath.Tests/TestResults/ParserTests.underline.(1123).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.underline.(1123).approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "PreviousAtom": null,

--- a/src/WpfMath.Tests/TestResults/ParserTests.underscoreText.approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.underscoreText.approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "Character": "_",

--- a/src/WpfMath.Tests/TestResults/ParserTests.unmatchedDelimiters.approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.unmatchedDelimiters.approved.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   "TextStyle": null,
   "RootAtom": {
     "BaseAtom": {

--- a/src/WpfMath.Tests/Utils.fs
+++ b/src/WpfMath.Tests/Utils.fs
@@ -1,4 +1,4 @@
-﻿module WpfMath.Tests.Utils
+module WpfMath.Tests.Utils
 
 open System
 open System.Windows

--- a/src/WpfMath.Tests/WpfMath.Tests.fsproj
+++ b/src/WpfMath.Tests/WpfMath.Tests.fsproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
     <PropertyGroup>
         <TargetFrameworks>netcoreapp3.0;net461</TargetFrameworks>
         <IsPackable>false</IsPackable>

--- a/src/WpfMath/Boxes/Box.cs
+++ b/src/WpfMath/Boxes/Box.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Windows.Media;
 using WpfMath.Rendering;

--- a/src/WpfMath/Boxes/CharBox.cs
+++ b/src/WpfMath/Boxes/CharBox.cs
@@ -1,4 +1,4 @@
-﻿using System.Windows;
+using System.Windows;
 using System.Windows.Media;
 using WpfMath.Rendering;
 

--- a/src/WpfMath/Boxes/HorizontalBox.cs
+++ b/src/WpfMath/Boxes/HorizontalBox.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Windows.Media;
 using WpfMath.Rendering;
 

--- a/src/WpfMath/Boxes/OverUnderBox.cs
+++ b/src/WpfMath/Boxes/OverUnderBox.cs
@@ -1,4 +1,4 @@
-﻿using WpfMath.Rendering;
+using WpfMath.Rendering;
 using WpfMath.Rendering.Transformations;
 
 namespace WpfMath.Boxes

--- a/src/WpfMath/Boxes/VerticalBox.cs
+++ b/src/WpfMath/Boxes/VerticalBox.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using WpfMath.Rendering;
 
 namespace WpfMath.Boxes

--- a/src/WpfMath/CharInfo.cs
+++ b/src/WpfMath/CharInfo.cs
@@ -1,4 +1,4 @@
-﻿using System.Windows.Media;
+using System.Windows.Media;
 
 namespace WpfMath
 {

--- a/src/WpfMath/Colors/PredefinedColorParser.cs
+++ b/src/WpfMath/Colors/PredefinedColorParser.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;

--- a/src/WpfMath/Controls/FormulaControl.xaml
+++ b/src/WpfMath/Controls/FormulaControl.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl x:Class="WpfMath.Controls.FormulaControl"
+<UserControl x:Class="WpfMath.Controls.FormulaControl"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 

--- a/src/WpfMath/Controls/VisualContainerElement.cs
+++ b/src/WpfMath/Controls/VisualContainerElement.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/WpfMath/Converters/SVGConverter.cs
+++ b/src/WpfMath/Converters/SVGConverter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/WpfMath/DefaultTexFont.cs
+++ b/src/WpfMath/DefaultTexFont.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using WpfMath.Exceptions;
 using WpfMath.Utils;

--- a/src/WpfMath/DelimiterInfo.cs
+++ b/src/WpfMath/DelimiterInfo.cs
@@ -1,4 +1,4 @@
-﻿using WpfMath.Atoms;
+using WpfMath.Atoms;
 
 namespace WpfMath
 {

--- a/src/WpfMath/Exceptions/TexCharacterMappingNotFoundException.cs
+++ b/src/WpfMath/Exceptions/TexCharacterMappingNotFoundException.cs
@@ -1,4 +1,4 @@
-﻿namespace WpfMath.Exceptions
+namespace WpfMath.Exceptions
 {
     public class TexCharacterMappingNotFoundException : TexException
     {

--- a/src/WpfMath/Exceptions/TexException.cs
+++ b/src/WpfMath/Exceptions/TexException.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace WpfMath.Exceptions
 {

--- a/src/WpfMath/Exceptions/TexNotSupportedException.cs
+++ b/src/WpfMath/Exceptions/TexNotSupportedException.cs
@@ -1,4 +1,4 @@
-﻿namespace WpfMath.Exceptions
+namespace WpfMath.Exceptions
 {
     public class TexNotSupportedException : TexException
     {

--- a/src/WpfMath/Exceptions/TexParseException.cs
+++ b/src/WpfMath/Exceptions/TexParseException.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace WpfMath.Exceptions
 {

--- a/src/WpfMath/Exceptions/TextStyleMappingNotFoundException.cs
+++ b/src/WpfMath/Exceptions/TextStyleMappingNotFoundException.cs
@@ -1,4 +1,4 @@
-﻿namespace WpfMath.Exceptions
+namespace WpfMath.Exceptions
 {
     public class TextStyleMappingNotFoundException : TexException
     {

--- a/src/WpfMath/Exceptions/TypeFaceNotFoundException.cs
+++ b/src/WpfMath/Exceptions/TypeFaceNotFoundException.cs
@@ -1,4 +1,4 @@
-﻿namespace WpfMath.Exceptions
+namespace WpfMath.Exceptions
 {
     public class TypeFaceNotFoundException : TexException
     {

--- a/src/WpfMath/Extensions.cs
+++ b/src/WpfMath/Extensions.cs
@@ -1,4 +1,4 @@
-﻿using System.Windows.Media.Imaging;
+using System.Windows.Media.Imaging;
 using System.IO;
 
 namespace WpfMath

--- a/src/WpfMath/Properties/AssemblyInfo.cs
+++ b/src/WpfMath/Properties/AssemblyInfo.cs
@@ -1,3 +1,3 @@
-﻿using System.Runtime.CompilerServices;
+using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("WpfMath.Tests")]

--- a/src/WpfMath/Rendering/GeometryElementRenderer.cs
+++ b/src/WpfMath/Rendering/GeometryElementRenderer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Windows;

--- a/src/WpfMath/Rendering/GeometryHelper.cs
+++ b/src/WpfMath/Rendering/GeometryHelper.cs
@@ -1,4 +1,4 @@
-﻿using System.Windows;
+using System.Windows;
 using System.Windows.Media;
 
 namespace WpfMath.Rendering

--- a/src/WpfMath/Rendering/IElementRenderer.cs
+++ b/src/WpfMath/Rendering/IElementRenderer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Windows;
 using System.Windows.Media;
 using WpfMath.Boxes;

--- a/src/WpfMath/Rendering/Transformations/Transformation.cs
+++ b/src/WpfMath/Rendering/Transformations/Transformation.cs
@@ -1,4 +1,4 @@
-﻿namespace WpfMath.Rendering.Transformations
+namespace WpfMath.Rendering.Transformations
 {
     /// <summary>Geometrical transformation.</summary>
     public abstract class Transformation

--- a/src/WpfMath/Rendering/Transformations/TransformationKind.cs
+++ b/src/WpfMath/Rendering/Transformations/TransformationKind.cs
@@ -1,4 +1,4 @@
-﻿namespace WpfMath.Rendering.Transformations
+namespace WpfMath.Rendering.Transformations
 {
     /// <summary>Kind of a geometrical transformation.</summary>
     public enum TransformationKind

--- a/src/WpfMath/Rendering/WpfElementRenderer.cs
+++ b/src/WpfMath/Rendering/WpfElementRenderer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Windows;
 using System.Windows.Media;

--- a/src/WpfMath/SystemFont.cs
+++ b/src/WpfMath/SystemFont.cs
@@ -1,4 +1,4 @@
-﻿using System.Globalization;
+using System.Globalization;
 using System.Windows;
 using System.Windows.Media;
 using WpfMath.Exceptions;

--- a/src/WpfMath/TexEnvironment.cs
+++ b/src/WpfMath/TexEnvironment.cs
@@ -1,4 +1,4 @@
-﻿using System.Windows.Media;
+using System.Windows.Media;
 
 namespace WpfMath
 {

--- a/src/WpfMath/TexFontInfo.cs
+++ b/src/WpfMath/TexFontInfo.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Windows.Media;
 using WpfMath.Exceptions;

--- a/src/WpfMath/TexFontUtilities.cs
+++ b/src/WpfMath/TexFontUtilities.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/WpfMath/TexRenderer.cs
+++ b/src/WpfMath/TexRenderer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Windows;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;

--- a/src/WpfMath/TexUtilities.cs
+++ b/src/WpfMath/TexUtilities.cs
@@ -1,4 +1,4 @@
-﻿namespace WpfMath
+namespace WpfMath
 {
     internal static class TexUtilities
     {

--- a/src/WpfMath/Utils/Result.cs
+++ b/src/WpfMath/Utils/Result.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace WpfMath.Utils
 {

--- a/src/WpfMath/XmlUtilities.cs
+++ b/src/WpfMath/XmlUtilities.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;


### PR DESCRIPTION
This PR removes UTF-8 BOM from all the files in the repository (where it was accidentally added), and also adds a validation to CI so nobody will be able to commit more BOMs.

The aBOMination will be stopped!

(I've verified that the latest VS2019/.NET Core SDK/Rider all work well with the sources encoded in UTF-8 without BOM.)

Closes #131.