### PR TITLE
Remove a misleading comment

### DIFF
--- a/src/WpfMath/TexFontInfo.cs
+++ b/src/WpfMath/TexFontInfo.cs
@@ -140,7 +140,6 @@ namespace WpfMath
             return this.XHeight * factor;
         }
 
-        /// <summary>Return the character metrics or <c>null</c> if the metrics weren't found.</summary>
         public Result<double[]> GetMetrics(char character)
         {
             if (this.metrics.Length <= character || this.metrics[character] == null)


### PR DESCRIPTION
The issue with this comment was noticed by @rstm-sf in #242.

This method never returns `null` (or `Result.Ok(null)`) and will return a `Result.Error` instead. I don't think that the comment without a remark about `null` holds any actual value, so I've decided to remove it completely.