### PR TITLE
Fix throw exception by \text{∅}

### DIFF
--- a/src/WpfMath.Tests/CharBoxTests.fs
+++ b/src/WpfMath.Tests/CharBoxTests.fs
@@ -15,10 +15,18 @@ open System
 type CharBoxTests() =
     static do Utils.initializeFontResourceLoading()
 
+    let parse(text: string) =
+        let parser = TexFormulaParser()
+        let result = parser.Parse text
+        result.RootAtom
+
+    let environment =
+        let mathFont = DefaultTexFont 20.0
+        let textFont = TexFormula.GetSystemFont("Arial", 20.0)
+        TexEnvironment(TexStyle.Display, mathFont, textFont)
+
     [<Fact>]
     member _.``CharBox rendering calls to RenderGlyphRun``() =
-        let font = DefaultTexFont 20.0
-        let environment = TexEnvironment(TexStyle.Display, font, font)
         let char = environment.MathFont.GetDefaultCharInfo('x', TexStyle.Display).Value
         let x = 0.5
         let y = 1.0
@@ -30,7 +38,13 @@ type CharBoxTests() =
 
     [<Fact>]
     member _.``Currently unsupporteded characters like "Å" should result in TexCharacterMappingNotFoundException``() =
-        let font = DefaultTexFont 20.0
-        let environment = TexEnvironment(TexStyle.Display, font, font)
         Assert.IsType<TexCharacterMappingNotFoundException>(
             environment.MathFont.GetDefaultCharInfo('Å', TexStyle.Display).Error)
+
+    [<Fact>]
+    member _.``CharBox GetGlyphRun for \text{∅} should throw the TexCharacterMappingNotFoundException``() =
+        let atom = parse @"\text{∅}"
+        let charBox : CharBox = downcast atom.CreateBox(environment)
+        let action = Func<obj>(fun () -> upcast charBox.GetGlyphRun(20.0, 0.5, 1.0))
+        let exc = Assert.Throws<TexCharacterMappingNotFoundException>(action)
+        Assert.Equal("The Arial font does not support '∅' (U+2205) character.", exc.Message)

--- a/src/WpfMath/Boxes/CharBox.cs
+++ b/src/WpfMath/Boxes/CharBox.cs
@@ -1,5 +1,7 @@
+using System.Linq;
 using System.Windows;
 using System.Windows.Media;
+using WpfMath.Exceptions;
 using WpfMath.Rendering;
 
 namespace WpfMath.Boxes
@@ -26,7 +28,14 @@ namespace WpfMath.Boxes
         internal GlyphRun GetGlyphRun(double scale, double x, double y)
         {
             var typeface = this.Character.Font;
-            var glyphIndex = typeface.CharacterToGlyphMap[this.Character.Character];
+            var characterInt = (int)this.Character.Character;
+            if (!typeface.CharacterToGlyphMap.TryGetValue(characterInt, out var glyphIndex))
+            {
+                var fontName = typeface.FamilyNames.Values.First();
+                var characterHex = characterInt.ToString("X4");
+                throw new TexCharacterMappingNotFoundException(
+                    $"The {fontName} font does not support '{this.Character.Character}' (U+{characterHex}) character.");
+            }
             var glyphRun = new GlyphRun(typeface, 0, false, this.Character.Size * scale,
                 new ushort[] { glyphIndex }, new Point(x * scale, y * scale),
                 new double[] { typeface.AdvanceWidths[glyphIndex] }, null, null, null, null, null, null);


### PR DESCRIPTION
Fixes #248