### PR TITLE
added support for \{ and \}

### DIFF
--- a/src/WpfMath/Data/DefaultTexFont.xml
+++ b/src/WpfMath/Data/DefaultTexFont.xml
@@ -110,7 +110,7 @@ for a text style is not defined (e.g. "numbers" and "small" in "mathcal") -->
     <SymbolMapping name="widehat" ch="98" fontId="2"/>
     <SymbolMapping name="widetilde" ch="101" fontId="2"/>
 
-    <!-- delimiters that can change size -->Q
+    <!-- delimiters that can change size -->
     <SymbolMapping name="{" ch="102" fontId="3"/>
     <SymbolMapping name="}" ch="103" fontId="3"/>
     <SymbolMapping name="lbrace" ch="102" fontId="3"/>

--- a/src/WpfMath/Data/DefaultTexFont.xml
+++ b/src/WpfMath/Data/DefaultTexFont.xml
@@ -110,8 +110,9 @@ for a text style is not defined (e.g. "numbers" and "small" in "mathcal") -->
     <SymbolMapping name="widehat" ch="98" fontId="2"/>
     <SymbolMapping name="widetilde" ch="101" fontId="2"/>
 
-    <!-- delimiters that can change size -->
-
+    <!-- delimiters that can change size -->Q
+    <SymbolMapping name="{" ch="102" fontId="3"/>
+    <SymbolMapping name="}" ch="103" fontId="3"/>
     <SymbolMapping name="lbrace" ch="102" fontId="3"/>
     <SymbolMapping name="rbrace" ch="103" fontId="3"/>
     <SymbolMapping name="(" ch="40" fontId="1"/>

--- a/src/WpfMath/Data/TexSymbols.xml
+++ b/src/WpfMath/Data/TexSymbols.xml
@@ -66,6 +66,8 @@
 
   <Symbol name="(" type="open" del="true"/>
   <Symbol name=")" type="close" del="true"/>
+  <Symbol name="{" type="open" del="true"/>
+  <Symbol name="}" type="close" del="true"/>
   <Symbol name="lbrace" type="open" del="true"/>
   <Symbol name="rbrace" type="close" del="true"/>
   <Symbol name="lbrack" type="open" del="true"/>


### PR DESCRIPTION
Added support for \\{ and \\} in addition to the existing \lbrace and \rbrace. These commands are in standard latex, but was missing here, making it incompatible.