### PR TITLE
Added equal padding to all sides when saving to bitmap

### DIFF
--- a/src/WpfMath.Tests/TexRendererTests.fs
+++ b/src/WpfMath.Tests/TexRendererTests.fs
@@ -17,9 +17,13 @@ let ``TexRenderer.RenderToBitmap should create an image of proper size with offs
     let parser = TexFormulaParser()
     let formula = parser.Parse "2+2=2"
     let renderer = formula.GetRenderer(TexStyle.Display, 20.0, "Arial")
-    let bitmap = renderer.RenderToBitmap(50.0, 50.0)
-    Assert.Equal(132, bitmap.PixelWidth)
-    Assert.Equal(66, bitmap.PixelHeight)
+    let margin=50;
+    let bitmap = renderer.RenderToBitmap(float(margin), float(margin))
+
+    let formulaWidth=82;
+    let formulaHeight=16;
+    Assert.Equal(formulaWidth+(margin*2), bitmap.PixelWidth)
+    Assert.Equal(formulaHeight+(margin*2), bitmap.PixelHeight)
 
 [<Fact>]
 let ``TexRenderer.RenderToBitmap should work with different DPI``() =

--- a/src/WpfMath/TexRenderer.cs
+++ b/src/WpfMath/TexRenderer.cs
@@ -82,8 +82,8 @@ namespace WpfMath
             this.RenderWithPositiveCoordinates(visual, x, y);
 
             var bounds = visual.ContentBounds;
-            var width = (int)Math.Ceiling(bounds.Right * dpi / DefaultDpi);
-            var height = (int)Math.Ceiling(bounds.Bottom * dpi / DefaultDpi);
+            var width = (int)Math.Ceiling((bounds.Right + x) * dpi / DefaultDpi);
+            var height = (int)Math.Ceiling((bounds.Bottom + y) * dpi / DefaultDpi);
             var bitmap = new RenderTargetBitmap(width, height, dpi, dpi, PixelFormats.Default);
             bitmap.Render(visual);
 


### PR DESCRIPTION
The RenderToBitmap(double x, double y) method only adds padding to the left and top side of the bitmap. This fix adds padding to bottom and right as well. Perhaps there should be a Thickness as input instead though? It would make more sense but is a breaking change.