### PR TITLE
Fix for scripts with curly braces after a command with  curly braces,…

### DIFF
--- a/src/WpfMath.Tests/ParserTests.fs
+++ b/src/WpfMath.Tests/ParserTests.fs
@@ -29,6 +29,10 @@ let emptyDelimiters(left : string, right : string, isLeftEmpty : bool, isRightEm
     <| sprintf @"\left%sa\right%s" left right
 
 [<Fact>]
+let subScripts() =
+    verifyParseResult @"\hat{a}_{b\sigma}"
+
+[<Fact>]
 let unmatchedDelimiters() =
     verifyParseResult @"\left)a\right|"
 

--- a/src/WpfMath.Tests/TestResults/ParserTests.subScripts.approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.subScripts.approved.txt
@@ -1,0 +1,124 @@
+{
+  "TextStyle": null,
+  "RootAtom": {
+    "[AtomType]": "RowAtom",
+    "PreviousAtom": null,
+    "Elements": [
+      {
+        "[AtomType]": "AccentedAtom",
+        "BaseAtom": {
+          "[AtomType]": "CharAtom",
+          "Character": "a",
+          "TextStyle": null,
+          "IsTextSymbol": false,
+          "Type": "Ordinary",
+          "Source": {
+            "Start": 5,
+            "End": 6,
+            "Length": 1,
+            "Source": "\\hat{a}_{b\\sigma}",
+            "SourceName": "User input"
+          }
+        },
+        "AccentAtom": {
+          "[AtomType]": "SymbolAtom",
+          "IsDelimeter": false,
+          "Name": "hat",
+          "IsTextSymbol": false,
+          "Type": "Accent",
+          "Source": null
+        },
+        "Type": "Ordinary",
+        "Source": {
+          "Start": 0,
+          "End": 4,
+          "Length": 4,
+          "Source": "\\hat{a}_{b\\sigma}",
+          "SourceName": "User input"
+        }
+      },
+      {
+        "[AtomType]": "ScriptsAtom",
+        "BaseAtom": {
+          "[AtomType]": "RowAtom",
+          "PreviousAtom": null,
+          "Elements": [],
+          "Type": "Ordinary",
+          "Source": {
+            "Start": 0,
+            "End": 17,
+            "Length": 17,
+            "Source": "\\hat{a}_{b\\sigma}",
+            "SourceName": "User input"
+          }
+        },
+        "SubscriptAtom": {
+          "[AtomType]": "RowAtom",
+          "PreviousAtom": null,
+          "Elements": [
+            {
+              "[AtomType]": "CharAtom",
+              "Character": "b",
+              "TextStyle": null,
+              "IsTextSymbol": false,
+              "Type": "Ordinary",
+              "Source": {
+                "Start": 9,
+                "End": 10,
+                "Length": 1,
+                "Source": "\\hat{a}_{b\\sigma}",
+                "SourceName": "User input"
+              }
+            },
+            {
+              "[AtomType]": "SymbolAtom",
+              "IsDelimeter": false,
+              "Name": "sigma",
+              "IsTextSymbol": false,
+              "Type": "Ordinary",
+              "Source": {
+                "Start": 11,
+                "End": 16,
+                "Length": 5,
+                "Source": "\\hat{a}_{b\\sigma}",
+                "SourceName": "User input"
+              }
+            }
+          ],
+          "Type": "Ordinary",
+          "Source": {
+            "Start": 1,
+            "End": 17,
+            "Length": 16,
+            "Source": "\\hat{a}_{b\\sigma}",
+            "SourceName": "User input"
+          }
+        },
+        "SuperscriptAtom": null,
+        "Type": "Ordinary",
+        "Source": {
+          "Start": 7,
+          "End": 17,
+          "Length": 10,
+          "Source": "\\hat{a}_{b\\sigma}",
+          "SourceName": "User input"
+        }
+      }
+    ],
+    "Type": "Ordinary",
+    "Source": {
+      "Start": 0,
+      "End": 17,
+      "Length": 17,
+      "Source": "\\hat{a}_{b\\sigma}",
+      "SourceName": "User input"
+    }
+  },
+  "Source": {
+    "Start": 0,
+    "End": 17,
+    "Length": 17,
+    "Source": "\\hat{a}_{b\\sigma}",
+    "SourceName": "User input"
+  }
+}

--- a/src/WpfMath/TexFormulaParser.cs
+++ b/src/WpfMath/TexFormulaParser.cs
@@ -268,7 +268,10 @@ namespace WpfMath
                             + superScriptChar + "\", \"" + subScriptChar + "\" and \""
                             + primeChar + "\" can't be the first character!");
                     else
-                        throw new TexParseException("Double scripts found! Try using more braces.");
+                    {
+                        var scriptsAtom = this.AttachScripts(formula, value, ref position, new RowAtom(value), true, environment);
+                        formula.Add(scriptsAtom, value.Segment(initialPosition, position));
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
Commands like e.g \hat{x}_{y} currenly throws an exception, but it should be valid latex. I've tested this change for a little while and have not encountered any problems.