### PR TITLE
Fixed crash on empty \sqrt{}

### DIFF
--- a/src/WpfMath/TexFormulaParser.cs
+++ b/src/WpfMath/TexFormulaParser.cs
@@ -534,6 +534,11 @@ namespace WpfMath
                             formula.TextStyle,
                             environment.CreateChildEnvironment());
 
+                        if (sqrtFormula.Source.Length == 0)
+                        {
+                            throw new TexParseException("An element is missing");
+                        }
+
                         source = value.Segment(start, position - start);
                         return new Tuple<AtomAppendMode, Atom>(
                             AtomAppendMode.Add,


### PR DESCRIPTION
This fixes a crash on an empty square root, like \sqrt{}