### PR TITLE
.gitignore cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,8 @@
 /.idea/
 /.vs/
-/packages/
 
 bin/
 obj/
 
-*.DotSettings
 *.received.txt
 *.user


### PR DESCRIPTION
Two items are getting removed:

- `/packages/` were added in ye olde times, and are only relevant for the old project system.

- `*.DotSettings` is ReSharper/Rider's way of sharing the settings (while any non-shared settings get written into `*.DotSettings.user`), so it shouldn't generally be ignored.