### PR TITLE
Fixed warnings about obsolete WPF API in .NET Core.

### DIFF
--- a/src/WpfMath/Boxes/CharBox.cs
+++ b/src/WpfMath/Boxes/CharBox.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using System.Linq;
 using System.Windows;
 using System.Windows.Media;
@@ -36,9 +37,20 @@ namespace WpfMath.Boxes
                 throw new TexCharacterMappingNotFoundException(
                     $"The {fontName} font does not support '{this.Character.Character}' (U+{characterHex}) character.");
             }
+#if NET452
             var glyphRun = new GlyphRun(typeface, 0, false, this.Character.Size * scale,
                 new ushort[] { glyphIndex }, new Point(x * scale, y * scale),
                 new double[] { typeface.AdvanceWidths[glyphIndex] }, null, null, null, null, null, null);
+#else
+            var glyphRun = new GlyphRun((float)scale);
+            ((ISupportInitialize)glyphRun).BeginInit();
+            glyphRun.GlyphTypeface = typeface;
+            glyphRun.FontRenderingEmSize = this.Character.Size * scale;
+            glyphRun.GlyphIndices = new[] { glyphIndex };
+            glyphRun.BaselineOrigin = new Point(x * scale, y * scale);
+            glyphRun.AdvanceWidths = new[] { typeface.AdvanceWidths[glyphIndex] };
+            ((ISupportInitialize)glyphRun).EndInit();
+#endif
             return glyphRun;
         }
 

--- a/src/WpfMath/SystemFont.cs
+++ b/src/WpfMath/SystemFont.cs
@@ -121,7 +121,7 @@ namespace WpfMath
                 typeface,
                 1.0,
                 Brushes.Black
-#if NETCOREAPP3_0
+#if !NET452
                 , 1
 #endif
                 );

--- a/src/WpfMath/SystemFont.cs
+++ b/src/WpfMath/SystemFont.cs
@@ -120,7 +120,11 @@ namespace WpfMath
                 FlowDirection.LeftToRight,
                 typeface,
                 1.0,
-                Brushes.Black);
+                Brushes.Black
+#if NETCOREAPP3_0
+                , 1
+#endif
+                );
             return new TexFontMetrics(formattedText.Width, formattedText.Height, 0.0, formattedText.Width, 1.0);
         }
 


### PR DESCRIPTION
Basically the new APIs require one to be explicit about pixels per DIP, which probably helps with high-DPI settings. This patch just gets rid of the warnings in a minimal way, while hopefully retaining the same functionality. It looks identical to me right now in both .NET 4 and .NET Core 3.1. I haven't yet tested with different DPI settings, though.

Intends to fix #232.