### PR TITLE
Fix typo in SystemTextFontNameProperty

### DIFF
--- a/src/WpfMath.Example/MainWindow.xaml
+++ b/src/WpfMath.Example/MainWindow.xaml
@@ -61,6 +61,7 @@
             <ScrollViewer Padding="4" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Disabled">
                 <controls:FormulaControl Name="Formula" Formula="{Binding Text, ElementName = InputTextBox, NotifyOnValidationError=True}"
                                          SelectionBrush="LightBlue"
+                                         SystemTextFontName="Arial"
                                          HorizontalAlignment="Stretch" VerticalAlignment="Stretch" SnapsToDevicePixels="True" />
             </ScrollViewer>
         </Border>

--- a/src/WpfMath/Controls/FormulaControl.xaml.cs
+++ b/src/WpfMath/Controls/FormulaControl.xaml.cs
@@ -81,7 +81,7 @@ namespace WpfMath.Controls
 
         public static readonly DependencyProperty SystemTextFontNameProperty = DependencyProperty.Register(
             nameof(SystemTextFontName), typeof(string), typeof(FormulaControl),
-            new PropertyMetadata("Arial", OnRenderSettingsChanged, CoerceScaleValue));
+            new PropertyMetadata("Arial", OnRenderSettingsChanged));
 
         public static readonly DependencyProperty HasErrorProperty = DependencyProperty.Register(
             nameof(HasError), typeof(bool), typeof(FormulaControl),


### PR DESCRIPTION
Hello!

Fix typo in `SystemTextFontNameProperty`

```
InvalidCastException: Unable to cast object of type 'System.String' to type 'System.Double'.
This exception was originally thrown at this call stack:
    WpfMath.Controls.FormulaControl.CoerceScaleValue(System.Windows.DependencyObject, object) in FormulaControl.xaml.cs
    System.Windows.DependencyObject.ProcessCoerceValue(System.Windows.DependencyProperty, System.Windows.PropertyMetadata, ref System.Windows.EntryIndex, ref int, ref System.Windows.EffectiveValueEntry, ref System.Windows.EffectiveValueEntry, ref object, object, object, System.Windows.CoerceValueCallback, bool, bool, bool)
    System.Windows.DependencyObject.UpdateEffectiveValue(System.Windows.EntryIndex, System.Windows.DependencyProperty, System.Windows.PropertyMetadata, System.Windows.EffectiveValueEntry, ref System.Windows.EffectiveValueEntry, bool, bool, System.Windows.OperationType)
    System.Windows.DependencyObject.SetValueCommon(System.Windows.DependencyProperty, object, System.Windows.PropertyMetadata, bool, bool, System.Windows.OperationType, bool)
    System.Windows.DependencyObject.SetValue(System.Windows.DependencyProperty, object)
    System.Windows.Baml2006.WpfMemberInvoker.SetValue(object, object)
    MS.Internal.Xaml.Runtime.ClrObjectRuntime.SetValue(System.Xaml.XamlMember, object, object)
    MS.Internal.Xaml.Runtime.ClrObjectRuntime.SetValue(object, System.Xaml.XamlMember, object)
```

https://github.com/ForNeVeR/wpf-math/blob/af5c330fecdaec39e85324292372228350724a2a/src/WpfMath/Controls/FormulaControl.xaml.cs#L180-L184