### PR TITLE
Added Atom types to test JSON data.

### DIFF
--- a/src/WpfMath.Tests/TestResults/ParserTests.2+2.approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.2+2.approved.txt
@@ -1,9 +1,11 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "RowAtom",
     "PreviousAtom": null,
     "Elements": [
       {
+        "[AtomType]": "CharAtom",
         "Character": "2",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -17,6 +19,7 @@
         }
       },
       {
+        "[AtomType]": "SymbolAtom",
         "IsDelimeter": false,
         "Name": "plus",
         "IsTextSymbol": false,
@@ -30,6 +33,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "2",
         "TextStyle": null,
         "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.bigMatrixExpression.approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.bigMatrixExpression.approved.txt
@@ -1,10 +1,13 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "RowAtom",
     "PreviousAtom": null,
     "Elements": [
       {
+        "[AtomType]": "ScriptsAtom",
         "BaseAtom": {
+          "[AtomType]": "SymbolAtom",
           "IsDelimeter": false,
           "Name": "Gamma",
           "IsTextSymbol": false,
@@ -18,9 +21,11 @@
           }
         },
         "SubscriptAtom": {
+          "[AtomType]": "RowAtom",
           "PreviousAtom": null,
           "Elements": [
             {
+              "[AtomType]": "SymbolAtom",
               "IsDelimeter": false,
               "Name": "mu",
               "IsTextSymbol": false,
@@ -34,6 +39,7 @@
               }
             },
             {
+              "[AtomType]": "SymbolAtom",
               "IsDelimeter": false,
               "Name": "rho",
               "IsTextSymbol": false,
@@ -57,6 +63,7 @@
           }
         },
         "SuperscriptAtom": {
+          "[AtomType]": "SymbolAtom",
           "IsDelimeter": false,
           "Name": "sigma",
           "IsTextSymbol": false,
@@ -79,6 +86,7 @@
         }
       },
       {
+        "[AtomType]": "SymbolAtom",
         "IsDelimeter": false,
         "Name": "equals",
         "IsTextSymbol": false,
@@ -92,14 +100,19 @@
         }
       },
       {
+        "[AtomType]": "FencedAtom",
         "BaseAtom": {
+          "[AtomType]": "MatrixAtom",
           "MatrixCells": [
             [
               {
+                "[AtomType]": "FencedAtom",
                 "BaseAtom": {
+                  "[AtomType]": "MatrixAtom",
                   "MatrixCells": [
                     [
                       {
+                        "[AtomType]": "CharAtom",
                         "Character": "0",
                         "TextStyle": null,
                         "IsTextSymbol": false,
@@ -113,6 +126,7 @@
                         }
                       },
                       {
+                        "[AtomType]": "CharAtom",
                         "Character": "0",
                         "TextStyle": null,
                         "IsTextSymbol": false,
@@ -126,6 +140,7 @@
                         }
                       },
                       {
+                        "[AtomType]": "CharAtom",
                         "Character": "0",
                         "TextStyle": null,
                         "IsTextSymbol": false,
@@ -141,6 +156,7 @@
                     ],
                     [
                       {
+                        "[AtomType]": "CharAtom",
                         "Character": "0",
                         "TextStyle": null,
                         "IsTextSymbol": false,
@@ -154,9 +170,11 @@
                         }
                       },
                       {
+                        "[AtomType]": "RowAtom",
                         "PreviousAtom": null,
                         "Elements": [
                           {
+                            "[AtomType]": "SymbolAtom",
                             "IsDelimeter": false,
                             "Name": "minus",
                             "IsTextSymbol": false,
@@ -170,6 +188,7 @@
                             }
                           },
                           {
+                            "[AtomType]": "CharAtom",
                             "Character": "r",
                             "TextStyle": null,
                             "IsTextSymbol": false,
@@ -193,6 +212,7 @@
                         }
                       },
                       {
+                        "[AtomType]": "CharAtom",
                         "Character": "0",
                         "TextStyle": null,
                         "IsTextSymbol": false,
@@ -208,6 +228,7 @@
                     ],
                     [
                       {
+                        "[AtomType]": "CharAtom",
                         "Character": "0",
                         "TextStyle": null,
                         "IsTextSymbol": false,
@@ -221,6 +242,7 @@
                         }
                       },
                       {
+                        "[AtomType]": "CharAtom",
                         "Character": "0",
                         "TextStyle": null,
                         "IsTextSymbol": false,
@@ -234,9 +256,11 @@
                         }
                       },
                       {
+                        "[AtomType]": "RowAtom",
                         "PreviousAtom": null,
                         "Elements": [
                           {
+                            "[AtomType]": "SymbolAtom",
                             "IsDelimeter": false,
                             "Name": "minus",
                             "IsTextSymbol": false,
@@ -250,6 +274,7 @@
                             }
                           },
                           {
+                            "[AtomType]": "CharAtom",
                             "Character": "r",
                             "TextStyle": null,
                             "IsTextSymbol": false,
@@ -263,6 +288,7 @@
                             }
                           },
                           {
+                            "[AtomType]": "CharAtom",
                             "Character": "s",
                             "TextStyle": null,
                             "IsTextSymbol": false,
@@ -276,6 +302,7 @@
                             }
                           },
                           {
+                            "[AtomType]": "CharAtom",
                             "Character": "i",
                             "TextStyle": null,
                             "IsTextSymbol": false,
@@ -289,7 +316,9 @@
                             }
                           },
                           {
+                            "[AtomType]": "ScriptsAtom",
                             "BaseAtom": {
+                              "[AtomType]": "CharAtom",
                               "Character": "n",
                               "TextStyle": null,
                               "IsTextSymbol": false,
@@ -304,6 +333,7 @@
                             },
                             "SubscriptAtom": null,
                             "SuperscriptAtom": {
+                              "[AtomType]": "CharAtom",
                               "Character": "2",
                               "TextStyle": null,
                               "IsTextSymbol": false,
@@ -326,6 +356,7 @@
                             }
                           },
                           {
+                            "[AtomType]": "SymbolAtom",
                             "IsDelimeter": true,
                             "Name": "(",
                             "IsTextSymbol": false,
@@ -339,6 +370,7 @@
                             }
                           },
                           {
+                            "[AtomType]": "SymbolAtom",
                             "IsDelimeter": false,
                             "Name": "theta",
                             "IsTextSymbol": false,
@@ -352,6 +384,7 @@
                             }
                           },
                           {
+                            "[AtomType]": "SymbolAtom",
                             "IsDelimeter": true,
                             "Name": ")",
                             "IsTextSymbol": false,
@@ -389,6 +422,7 @@
                   }
                 },
                 "LeftDelimeter": {
+                  "[AtomType]": "SymbolAtom",
                   "IsDelimeter": true,
                   "Name": "lbrack",
                   "IsTextSymbol": false,
@@ -396,6 +430,7 @@
                   "Source": null
                 },
                 "RightDelimeter": {
+                  "[AtomType]": "SymbolAtom",
                   "IsDelimeter": true,
                   "Name": "rbrack",
                   "IsTextSymbol": false,
@@ -414,10 +449,13 @@
             ],
             [
               {
+                "[AtomType]": "FencedAtom",
                 "BaseAtom": {
+                  "[AtomType]": "MatrixAtom",
                   "MatrixCells": [
                     [
                       {
+                        "[AtomType]": "CharAtom",
                         "Character": "0",
                         "TextStyle": null,
                         "IsTextSymbol": false,
@@ -431,7 +469,9 @@
                         }
                       },
                       {
+                        "[AtomType]": "FractionAtom",
                         "Numerator": {
+                          "[AtomType]": "CharAtom",
                           "Character": "1",
                           "TextStyle": null,
                           "IsTextSymbol": false,
@@ -445,6 +485,7 @@
                           }
                         },
                         "Denominator": {
+                          "[AtomType]": "CharAtom",
                           "Character": "r",
                           "TextStyle": null,
                           "IsTextSymbol": false,
@@ -467,6 +508,7 @@
                         }
                       },
                       {
+                        "[AtomType]": "CharAtom",
                         "Character": "0",
                         "TextStyle": null,
                         "IsTextSymbol": false,
@@ -482,7 +524,9 @@
                     ],
                     [
                       {
+                        "[AtomType]": "FractionAtom",
                         "Numerator": {
+                          "[AtomType]": "CharAtom",
                           "Character": "1",
                           "TextStyle": null,
                           "IsTextSymbol": false,
@@ -496,6 +540,7 @@
                           }
                         },
                         "Denominator": {
+                          "[AtomType]": "CharAtom",
                           "Character": "r",
                           "TextStyle": null,
                           "IsTextSymbol": false,
@@ -518,6 +563,7 @@
                         }
                       },
                       {
+                        "[AtomType]": "CharAtom",
                         "Character": "0",
                         "TextStyle": null,
                         "IsTextSymbol": false,
@@ -531,6 +577,7 @@
                         }
                       },
                       {
+                        "[AtomType]": "CharAtom",
                         "Character": "0",
                         "TextStyle": null,
                         "IsTextSymbol": false,
@@ -546,6 +593,7 @@
                     ],
                     [
                       {
+                        "[AtomType]": "CharAtom",
                         "Character": "0",
                         "TextStyle": null,
                         "IsTextSymbol": false,
@@ -559,6 +607,7 @@
                         }
                       },
                       {
+                        "[AtomType]": "CharAtom",
                         "Character": "0",
                         "TextStyle": null,
                         "IsTextSymbol": false,
@@ -572,9 +621,11 @@
                         }
                       },
                       {
+                        "[AtomType]": "RowAtom",
                         "PreviousAtom": null,
                         "Elements": [
                           {
+                            "[AtomType]": "SymbolAtom",
                             "IsDelimeter": false,
                             "Name": "minus",
                             "IsTextSymbol": false,
@@ -588,10 +639,13 @@
                             }
                           },
                           {
+                            "[AtomType]": "BigOperatorAtom",
                             "BaseAtom": {
+                              "[AtomType]": "RowAtom",
                               "PreviousAtom": null,
                               "Elements": [
                                 {
+                                  "[AtomType]": "CharAtom",
                                   "Character": "s",
                                   "TextStyle": "mathrm",
                                   "IsTextSymbol": false,
@@ -605,6 +659,7 @@
                                   }
                                 },
                                 {
+                                  "[AtomType]": "CharAtom",
                                   "Character": "i",
                                   "TextStyle": "mathrm",
                                   "IsTextSymbol": false,
@@ -618,6 +673,7 @@
                                   }
                                 },
                                 {
+                                  "[AtomType]": "CharAtom",
                                   "Character": "n",
                                   "TextStyle": "mathrm",
                                   "IsTextSymbol": false,
@@ -653,6 +709,7 @@
                             }
                           },
                           {
+                            "[AtomType]": "SymbolAtom",
                             "IsDelimeter": true,
                             "Name": "(",
                             "IsTextSymbol": false,
@@ -666,6 +723,7 @@
                             }
                           },
                           {
+                            "[AtomType]": "SymbolAtom",
                             "IsDelimeter": false,
                             "Name": "theta",
                             "IsTextSymbol": false,
@@ -679,6 +737,7 @@
                             }
                           },
                           {
+                            "[AtomType]": "SymbolAtom",
                             "IsDelimeter": true,
                             "Name": ")",
                             "IsTextSymbol": false,
@@ -692,10 +751,13 @@
                             }
                           },
                           {
+                            "[AtomType]": "BigOperatorAtom",
                             "BaseAtom": {
+                              "[AtomType]": "RowAtom",
                               "PreviousAtom": null,
                               "Elements": [
                                 {
+                                  "[AtomType]": "CharAtom",
                                   "Character": "c",
                                   "TextStyle": "mathrm",
                                   "IsTextSymbol": false,
@@ -709,6 +771,7 @@
                                   }
                                 },
                                 {
+                                  "[AtomType]": "CharAtom",
                                   "Character": "o",
                                   "TextStyle": "mathrm",
                                   "IsTextSymbol": false,
@@ -722,6 +785,7 @@
                                   }
                                 },
                                 {
+                                  "[AtomType]": "CharAtom",
                                   "Character": "s",
                                   "TextStyle": "mathrm",
                                   "IsTextSymbol": false,
@@ -757,6 +821,7 @@
                             }
                           },
                           {
+                            "[AtomType]": "SymbolAtom",
                             "IsDelimeter": true,
                             "Name": "(",
                             "IsTextSymbol": false,
@@ -770,6 +835,7 @@
                             }
                           },
                           {
+                            "[AtomType]": "SymbolAtom",
                             "IsDelimeter": false,
                             "Name": "theta",
                             "IsTextSymbol": false,
@@ -783,6 +849,7 @@
                             }
                           },
                           {
+                            "[AtomType]": "SymbolAtom",
                             "IsDelimeter": true,
                             "Name": ")",
                             "IsTextSymbol": false,
@@ -820,6 +887,7 @@
                   }
                 },
                 "LeftDelimeter": {
+                  "[AtomType]": "SymbolAtom",
                   "IsDelimeter": true,
                   "Name": "lbrack",
                   "IsTextSymbol": false,
@@ -827,6 +895,7 @@
                   "Source": null
                 },
                 "RightDelimeter": {
+                  "[AtomType]": "SymbolAtom",
                   "IsDelimeter": true,
                   "Name": "rbrack",
                   "IsTextSymbol": false,
@@ -845,10 +914,13 @@
             ],
             [
               {
+                "[AtomType]": "FencedAtom",
                 "BaseAtom": {
+                  "[AtomType]": "MatrixAtom",
                   "MatrixCells": [
                     [
                       {
+                        "[AtomType]": "CharAtom",
                         "Character": "0",
                         "TextStyle": null,
                         "IsTextSymbol": false,
@@ -862,6 +934,7 @@
                         }
                       },
                       {
+                        "[AtomType]": "CharAtom",
                         "Character": "0",
                         "TextStyle": null,
                         "IsTextSymbol": false,
@@ -875,7 +948,9 @@
                         }
                       },
                       {
+                        "[AtomType]": "FractionAtom",
                         "Numerator": {
+                          "[AtomType]": "CharAtom",
                           "Character": "1",
                           "TextStyle": null,
                           "IsTextSymbol": false,
@@ -889,6 +964,7 @@
                           }
                         },
                         "Denominator": {
+                          "[AtomType]": "CharAtom",
                           "Character": "r",
                           "TextStyle": null,
                           "IsTextSymbol": false,
@@ -913,6 +989,7 @@
                     ],
                     [
                       {
+                        "[AtomType]": "CharAtom",
                         "Character": "0",
                         "TextStyle": null,
                         "IsTextSymbol": false,
@@ -926,6 +1003,7 @@
                         }
                       },
                       {
+                        "[AtomType]": "CharAtom",
                         "Character": "0",
                         "TextStyle": null,
                         "IsTextSymbol": false,
@@ -939,7 +1017,9 @@
                         }
                       },
                       {
+                        "[AtomType]": "FractionAtom",
                         "Numerator": {
+                          "[AtomType]": "CharAtom",
                           "Character": "1",
                           "TextStyle": null,
                           "IsTextSymbol": false,
@@ -953,13 +1033,17 @@
                           }
                         },
                         "Denominator": {
+                          "[AtomType]": "RowAtom",
                           "PreviousAtom": null,
                           "Elements": [
                             {
+                              "[AtomType]": "BigOperatorAtom",
                               "BaseAtom": {
+                                "[AtomType]": "RowAtom",
                                 "PreviousAtom": null,
                                 "Elements": [
                                   {
+                                    "[AtomType]": "CharAtom",
                                     "Character": "t",
                                     "TextStyle": "mathrm",
                                     "IsTextSymbol": false,
@@ -973,6 +1057,7 @@
                                     }
                                   },
                                   {
+                                    "[AtomType]": "CharAtom",
                                     "Character": "a",
                                     "TextStyle": "mathrm",
                                     "IsTextSymbol": false,
@@ -986,6 +1071,7 @@
                                     }
                                   },
                                   {
+                                    "[AtomType]": "CharAtom",
                                     "Character": "n",
                                     "TextStyle": "mathrm",
                                     "IsTextSymbol": false,
@@ -1021,6 +1107,7 @@
                               }
                             },
                             {
+                              "[AtomType]": "SymbolAtom",
                               "IsDelimeter": true,
                               "Name": "(",
                               "IsTextSymbol": false,
@@ -1034,6 +1121,7 @@
                               }
                             },
                             {
+                              "[AtomType]": "SymbolAtom",
                               "IsDelimeter": false,
                               "Name": "theta",
                               "IsTextSymbol": false,
@@ -1047,6 +1135,7 @@
                               }
                             },
                             {
+                              "[AtomType]": "SymbolAtom",
                               "IsDelimeter": true,
                               "Name": ")",
                               "IsTextSymbol": false,
@@ -1081,7 +1170,9 @@
                     ],
                     [
                       {
+                        "[AtomType]": "FractionAtom",
                         "Numerator": {
+                          "[AtomType]": "CharAtom",
                           "Character": "1",
                           "TextStyle": null,
                           "IsTextSymbol": false,
@@ -1095,6 +1186,7 @@
                           }
                         },
                         "Denominator": {
+                          "[AtomType]": "CharAtom",
                           "Character": "r",
                           "TextStyle": null,
                           "IsTextSymbol": false,
@@ -1117,7 +1209,9 @@
                         }
                       },
                       {
+                        "[AtomType]": "FractionAtom",
                         "Numerator": {
+                          "[AtomType]": "CharAtom",
                           "Character": "1",
                           "TextStyle": null,
                           "IsTextSymbol": false,
@@ -1131,13 +1225,17 @@
                           }
                         },
                         "Denominator": {
+                          "[AtomType]": "RowAtom",
                           "PreviousAtom": null,
                           "Elements": [
                             {
+                              "[AtomType]": "BigOperatorAtom",
                               "BaseAtom": {
+                                "[AtomType]": "RowAtom",
                                 "PreviousAtom": null,
                                 "Elements": [
                                   {
+                                    "[AtomType]": "CharAtom",
                                     "Character": "t",
                                     "TextStyle": "mathrm",
                                     "IsTextSymbol": false,
@@ -1151,6 +1249,7 @@
                                     }
                                   },
                                   {
+                                    "[AtomType]": "CharAtom",
                                     "Character": "a",
                                     "TextStyle": "mathrm",
                                     "IsTextSymbol": false,
@@ -1164,6 +1263,7 @@
                                     }
                                   },
                                   {
+                                    "[AtomType]": "CharAtom",
                                     "Character": "n",
                                     "TextStyle": "mathrm",
                                     "IsTextSymbol": false,
@@ -1199,6 +1299,7 @@
                               }
                             },
                             {
+                              "[AtomType]": "SymbolAtom",
                               "IsDelimeter": true,
                               "Name": "(",
                               "IsTextSymbol": false,
@@ -1212,6 +1313,7 @@
                               }
                             },
                             {
+                              "[AtomType]": "SymbolAtom",
                               "IsDelimeter": false,
                               "Name": "theta",
                               "IsTextSymbol": false,
@@ -1225,6 +1327,7 @@
                               }
                             },
                             {
+                              "[AtomType]": "SymbolAtom",
                               "IsDelimeter": true,
                               "Name": ")",
                               "IsTextSymbol": false,
@@ -1257,6 +1360,7 @@
                         }
                       },
                       {
+                        "[AtomType]": "CharAtom",
                         "Character": "0",
                         "TextStyle": null,
                         "IsTextSymbol": false,
@@ -1284,6 +1388,7 @@
                   }
                 },
                 "LeftDelimeter": {
+                  "[AtomType]": "SymbolAtom",
                   "IsDelimeter": true,
                   "Name": "lbrack",
                   "IsTextSymbol": false,
@@ -1291,6 +1396,7 @@
                   "Source": null
                 },
                 "RightDelimeter": {
+                  "[AtomType]": "SymbolAtom",
                   "IsDelimeter": true,
                   "Name": "rbrack",
                   "IsTextSymbol": false,
@@ -1321,6 +1427,7 @@
           }
         },
         "LeftDelimeter": {
+          "[AtomType]": "SymbolAtom",
           "IsDelimeter": true,
           "Name": "lbrack",
           "IsTextSymbol": false,
@@ -1328,6 +1435,7 @@
           "Source": null
         },
         "RightDelimeter": {
+          "[AtomType]": "SymbolAtom",
           "IsDelimeter": true,
           "Name": "rbrack",
           "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.binom.( 2 x123).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.binom.( 2 x123).approved.txt
@@ -1,13 +1,17 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "RowAtom",
     "PreviousAtom": null,
     "Elements": [
       {
+        "[AtomType]": "FencedAtom",
         "BaseAtom": {
+          "[AtomType]": "MatrixAtom",
           "MatrixCells": [
             [
               {
+                "[AtomType]": "CharAtom",
                 "Character": "2",
                 "TextStyle": null,
                 "IsTextSymbol": false,
@@ -23,6 +27,7 @@
             ],
             [
               {
+                "[AtomType]": "CharAtom",
                 "Character": "x",
                 "TextStyle": null,
                 "IsTextSymbol": false,
@@ -50,6 +55,7 @@
           }
         },
         "LeftDelimeter": {
+          "[AtomType]": "SymbolAtom",
           "IsDelimeter": true,
           "Name": "(",
           "IsTextSymbol": false,
@@ -63,6 +69,7 @@
           }
         },
         "RightDelimeter": {
+          "[AtomType]": "SymbolAtom",
           "IsDelimeter": true,
           "Name": ")",
           "IsTextSymbol": false,
@@ -85,6 +92,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "1",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -98,6 +106,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "2",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -111,6 +120,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "3",
         "TextStyle": null,
         "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.binom.( 2(x)123).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.binom.( 2(x)123).approved.txt
@@ -1,13 +1,17 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "RowAtom",
     "PreviousAtom": null,
     "Elements": [
       {
+        "[AtomType]": "FencedAtom",
         "BaseAtom": {
+          "[AtomType]": "MatrixAtom",
           "MatrixCells": [
             [
               {
+                "[AtomType]": "CharAtom",
                 "Character": "2",
                 "TextStyle": null,
                 "IsTextSymbol": false,
@@ -23,6 +27,7 @@
             ],
             [
               {
+                "[AtomType]": "CharAtom",
                 "Character": "x",
                 "TextStyle": null,
                 "IsTextSymbol": false,
@@ -50,6 +55,7 @@
           }
         },
         "LeftDelimeter": {
+          "[AtomType]": "SymbolAtom",
           "IsDelimeter": true,
           "Name": "(",
           "IsTextSymbol": false,
@@ -63,6 +69,7 @@
           }
         },
         "RightDelimeter": {
+          "[AtomType]": "SymbolAtom",
           "IsDelimeter": true,
           "Name": ")",
           "IsTextSymbol": false,
@@ -85,6 +92,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "1",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -98,6 +106,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "2",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -111,6 +120,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "3",
         "TextStyle": null,
         "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.binom.((2)(x)123).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.binom.((2)(x)123).approved.txt
@@ -1,13 +1,17 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "RowAtom",
     "PreviousAtom": null,
     "Elements": [
       {
+        "[AtomType]": "FencedAtom",
         "BaseAtom": {
+          "[AtomType]": "MatrixAtom",
           "MatrixCells": [
             [
               {
+                "[AtomType]": "CharAtom",
                 "Character": "2",
                 "TextStyle": null,
                 "IsTextSymbol": false,
@@ -23,6 +27,7 @@
             ],
             [
               {
+                "[AtomType]": "CharAtom",
                 "Character": "x",
                 "TextStyle": null,
                 "IsTextSymbol": false,
@@ -50,6 +55,7 @@
           }
         },
         "LeftDelimeter": {
+          "[AtomType]": "SymbolAtom",
           "IsDelimeter": true,
           "Name": "(",
           "IsTextSymbol": false,
@@ -63,6 +69,7 @@
           }
         },
         "RightDelimeter": {
+          "[AtomType]": "SymbolAtom",
           "IsDelimeter": true,
           "Name": ")",
           "IsTextSymbol": false,
@@ -85,6 +92,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "1",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -98,6 +106,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "2",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -111,6 +120,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "3",
         "TextStyle": null,
         "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.binom.((2)x123).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.binom.((2)x123).approved.txt
@@ -1,13 +1,17 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "RowAtom",
     "PreviousAtom": null,
     "Elements": [
       {
+        "[AtomType]": "FencedAtom",
         "BaseAtom": {
+          "[AtomType]": "MatrixAtom",
           "MatrixCells": [
             [
               {
+                "[AtomType]": "CharAtom",
                 "Character": "2",
                 "TextStyle": null,
                 "IsTextSymbol": false,
@@ -23,6 +27,7 @@
             ],
             [
               {
+                "[AtomType]": "CharAtom",
                 "Character": "x",
                 "TextStyle": null,
                 "IsTextSymbol": false,
@@ -50,6 +55,7 @@
           }
         },
         "LeftDelimeter": {
+          "[AtomType]": "SymbolAtom",
           "IsDelimeter": true,
           "Name": "(",
           "IsTextSymbol": false,
@@ -63,6 +69,7 @@
           }
         },
         "RightDelimeter": {
+          "[AtomType]": "SymbolAtom",
           "IsDelimeter": true,
           "Name": ")",
           "IsTextSymbol": false,
@@ -85,6 +92,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "1",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -98,6 +106,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "2",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -111,6 +120,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "3",
         "TextStyle": null,
         "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.binom.(2 (x)123).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.binom.(2 (x)123).approved.txt
@@ -1,13 +1,17 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "RowAtom",
     "PreviousAtom": null,
     "Elements": [
       {
+        "[AtomType]": "FencedAtom",
         "BaseAtom": {
+          "[AtomType]": "MatrixAtom",
           "MatrixCells": [
             [
               {
+                "[AtomType]": "CharAtom",
                 "Character": "2",
                 "TextStyle": null,
                 "IsTextSymbol": false,
@@ -23,6 +27,7 @@
             ],
             [
               {
+                "[AtomType]": "CharAtom",
                 "Character": "x",
                 "TextStyle": null,
                 "IsTextSymbol": false,
@@ -50,6 +55,7 @@
           }
         },
         "LeftDelimeter": {
+          "[AtomType]": "SymbolAtom",
           "IsDelimeter": true,
           "Name": "(",
           "IsTextSymbol": false,
@@ -63,6 +69,7 @@
           }
         },
         "RightDelimeter": {
+          "[AtomType]": "SymbolAtom",
           "IsDelimeter": true,
           "Name": ")",
           "IsTextSymbol": false,
@@ -85,6 +92,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "1",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -98,6 +106,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "2",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -111,6 +120,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "3",
         "TextStyle": null,
         "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.binom.(2(x)123).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.binom.(2(x)123).approved.txt
@@ -1,13 +1,17 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "RowAtom",
     "PreviousAtom": null,
     "Elements": [
       {
+        "[AtomType]": "FencedAtom",
         "BaseAtom": {
+          "[AtomType]": "MatrixAtom",
           "MatrixCells": [
             [
               {
+                "[AtomType]": "CharAtom",
                 "Character": "2",
                 "TextStyle": null,
                 "IsTextSymbol": false,
@@ -23,6 +27,7 @@
             ],
             [
               {
+                "[AtomType]": "CharAtom",
                 "Character": "x",
                 "TextStyle": null,
                 "IsTextSymbol": false,
@@ -50,6 +55,7 @@
           }
         },
         "LeftDelimeter": {
+          "[AtomType]": "SymbolAtom",
           "IsDelimeter": true,
           "Name": "(",
           "IsTextSymbol": false,
@@ -63,6 +69,7 @@
           }
         },
         "RightDelimeter": {
+          "[AtomType]": "SymbolAtom",
           "IsDelimeter": true,
           "Name": ")",
           "IsTextSymbol": false,
@@ -85,6 +92,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "1",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -98,6 +106,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "2",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -111,6 +120,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "3",
         "TextStyle": null,
         "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.binom.(2x123).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.binom.(2x123).approved.txt
@@ -1,13 +1,17 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "RowAtom",
     "PreviousAtom": null,
     "Elements": [
       {
+        "[AtomType]": "FencedAtom",
         "BaseAtom": {
+          "[AtomType]": "MatrixAtom",
           "MatrixCells": [
             [
               {
+                "[AtomType]": "CharAtom",
                 "Character": "2",
                 "TextStyle": null,
                 "IsTextSymbol": false,
@@ -23,6 +27,7 @@
             ],
             [
               {
+                "[AtomType]": "CharAtom",
                 "Character": "x",
                 "TextStyle": null,
                 "IsTextSymbol": false,
@@ -50,6 +55,7 @@
           }
         },
         "LeftDelimeter": {
+          "[AtomType]": "SymbolAtom",
           "IsDelimeter": true,
           "Name": "(",
           "IsTextSymbol": false,
@@ -63,6 +69,7 @@
           }
         },
         "RightDelimeter": {
+          "[AtomType]": "SymbolAtom",
           "IsDelimeter": true,
           "Name": ")",
           "IsTextSymbol": false,
@@ -85,6 +92,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "1",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -98,6 +106,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "2",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -111,6 +120,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "3",
         "TextStyle": null,
         "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.color.((red) (1)123).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.color.((red) (1)123).approved.txt
@@ -1,13 +1,17 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "RowAtom",
     "PreviousAtom": null,
     "Elements": [
       {
+        "[AtomType]": "StyledAtom",
         "RowAtom": {
+          "[AtomType]": "RowAtom",
           "PreviousAtom": null,
           "Elements": [
             {
+              "[AtomType]": "CharAtom",
               "Character": "1",
               "TextStyle": null,
               "IsTextSymbol": false,
@@ -42,6 +46,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "1",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -55,6 +60,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "2",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -68,6 +74,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "3",
         "TextStyle": null,
         "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.color.((red) 1123).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.color.((red) 1123).approved.txt
@@ -1,13 +1,17 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "RowAtom",
     "PreviousAtom": null,
     "Elements": [
       {
+        "[AtomType]": "StyledAtom",
         "RowAtom": {
+          "[AtomType]": "RowAtom",
           "PreviousAtom": null,
           "Elements": [
             {
+              "[AtomType]": "CharAtom",
               "Character": "1",
               "TextStyle": null,
               "IsTextSymbol": false,
@@ -42,6 +46,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "1",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -55,6 +60,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "2",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -68,6 +74,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "3",
         "TextStyle": null,
         "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.color.((red)(1)123).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.color.((red)(1)123).approved.txt
@@ -1,13 +1,17 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "RowAtom",
     "PreviousAtom": null,
     "Elements": [
       {
+        "[AtomType]": "StyledAtom",
         "RowAtom": {
+          "[AtomType]": "RowAtom",
           "PreviousAtom": null,
           "Elements": [
             {
+              "[AtomType]": "CharAtom",
               "Character": "1",
               "TextStyle": null,
               "IsTextSymbol": false,
@@ -42,6 +46,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "1",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -55,6 +60,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "2",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -68,6 +74,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "3",
         "TextStyle": null,
         "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.color.((red)1123).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.color.((red)1123).approved.txt
@@ -1,13 +1,17 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "RowAtom",
     "PreviousAtom": null,
     "Elements": [
       {
+        "[AtomType]": "StyledAtom",
         "RowAtom": {
+          "[AtomType]": "RowAtom",
           "PreviousAtom": null,
           "Elements": [
             {
+              "[AtomType]": "CharAtom",
               "Character": "1",
               "TextStyle": null,
               "IsTextSymbol": false,
@@ -42,6 +46,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "1",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -55,6 +60,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "2",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -68,6 +74,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "3",
         "TextStyle": null,
         "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.colorModels.(color (red) x).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.colorModels.(color (red) x).approved.txt
@@ -1,10 +1,13 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "StyledAtom",
     "RowAtom": {
+      "[AtomType]": "RowAtom",
       "PreviousAtom": null,
       "Elements": [
         {
+          "[AtomType]": "CharAtom",
           "Character": "x",
           "TextStyle": null,
           "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.colorModels.(color [HTML] (abcdef) x).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.colorModels.(color [HTML] (abcdef) x).approved.txt
@@ -1,10 +1,13 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "StyledAtom",
     "RowAtom": {
+      "[AtomType]": "RowAtom",
       "PreviousAtom": null,
       "Elements": [
         {
+          "[AtomType]": "CharAtom",
           "Character": "x",
           "TextStyle": null,
           "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.colorModels.(color [RGB] (128, 128, 128) x).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.colorModels.(color [RGB] (128, 128, 128) x).approved.txt
@@ -1,10 +1,13 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "StyledAtom",
     "RowAtom": {
+      "[AtomType]": "RowAtom",
       "PreviousAtom": null,
       "Elements": [
         {
+          "[AtomType]": "CharAtom",
           "Character": "x",
           "TextStyle": null,
           "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.colorModels.(color [] (red) x).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.colorModels.(color [] (red) x).approved.txt
@@ -1,10 +1,13 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "StyledAtom",
     "RowAtom": {
+      "[AtomType]": "RowAtom",
       "PreviousAtom": null,
       "Elements": [
         {
+          "[AtomType]": "CharAtom",
           "Character": "x",
           "TextStyle": null,
           "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.colorModels.(color [cmyk] (0.5, 0.5, 0.5, 0.5) x).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.colorModels.(color [cmyk] (0.5, 0.5, 0.5, 0.5) x).approved.txt
@@ -1,10 +1,13 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "StyledAtom",
     "RowAtom": {
+      "[AtomType]": "RowAtom",
       "PreviousAtom": null,
       "Elements": [
         {
+          "[AtomType]": "CharAtom",
           "Character": "x",
           "TextStyle": null,
           "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.colorModels.(color [gray] (0.5) x).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.colorModels.(color [gray] (0.5) x).approved.txt
@@ -1,10 +1,13 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "StyledAtom",
     "RowAtom": {
+      "[AtomType]": "RowAtom",
       "PreviousAtom": null,
       "Elements": [
         {
+          "[AtomType]": "CharAtom",
           "Character": "x",
           "TextStyle": null,
           "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.colorModels.(color [rgb] (0.5, 0.5, 0.5) x).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.colorModels.(color [rgb] (0.5, 0.5, 0.5) x).approved.txt
@@ -1,10 +1,13 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "StyledAtom",
     "RowAtom": {
+      "[AtomType]": "RowAtom",
       "PreviousAtom": null,
       "Elements": [
         {
+          "[AtomType]": "CharAtom",
           "Character": "x",
           "TextStyle": null,
           "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.colorModels.(colorbox (red) x).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.colorModels.(colorbox (red) x).approved.txt
@@ -1,10 +1,13 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "StyledAtom",
     "RowAtom": {
+      "[AtomType]": "RowAtom",
       "PreviousAtom": null,
       "Elements": [
         {
+          "[AtomType]": "CharAtom",
           "Character": "x",
           "TextStyle": null,
           "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.colorModels.(colorbox [HTML] (abcdef) x).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.colorModels.(colorbox [HTML] (abcdef) x).approved.txt
@@ -1,10 +1,13 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "StyledAtom",
     "RowAtom": {
+      "[AtomType]": "RowAtom",
       "PreviousAtom": null,
       "Elements": [
         {
+          "[AtomType]": "CharAtom",
           "Character": "x",
           "TextStyle": null,
           "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.colorModels.(colorbox [RGB] (128, 128, 128) x).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.colorModels.(colorbox [RGB] (128, 128, 128) x).approved.txt
@@ -1,10 +1,13 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "StyledAtom",
     "RowAtom": {
+      "[AtomType]": "RowAtom",
       "PreviousAtom": null,
       "Elements": [
         {
+          "[AtomType]": "CharAtom",
           "Character": "x",
           "TextStyle": null,
           "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.colorModels.(colorbox [] (red) x).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.colorModels.(colorbox [] (red) x).approved.txt
@@ -1,10 +1,13 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "StyledAtom",
     "RowAtom": {
+      "[AtomType]": "RowAtom",
       "PreviousAtom": null,
       "Elements": [
         {
+          "[AtomType]": "CharAtom",
           "Character": "x",
           "TextStyle": null,
           "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.colorModels.(colorbox [cmyk] (0.5, 0.5, 0.5, 0.5) x).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.colorModels.(colorbox [cmyk] (0.5, 0.5, 0.5, 0.5) x).approved.txt
@@ -1,10 +1,13 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "StyledAtom",
     "RowAtom": {
+      "[AtomType]": "RowAtom",
       "PreviousAtom": null,
       "Elements": [
         {
+          "[AtomType]": "CharAtom",
           "Character": "x",
           "TextStyle": null,
           "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.colorModels.(colorbox [gray] (0.5) x).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.colorModels.(colorbox [gray] (0.5) x).approved.txt
@@ -1,10 +1,13 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "StyledAtom",
     "RowAtom": {
+      "[AtomType]": "RowAtom",
       "PreviousAtom": null,
       "Elements": [
         {
+          "[AtomType]": "CharAtom",
           "Character": "x",
           "TextStyle": null,
           "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.colorModels.(colorbox [rgb] (0.5, 0.5, 0.5) x).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.colorModels.(colorbox [rgb] (0.5, 0.5, 0.5) x).approved.txt
@@ -1,10 +1,13 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "StyledAtom",
     "RowAtom": {
+      "[AtomType]": "RowAtom",
       "PreviousAtom": null,
       "Elements": [
         {
+          "[AtomType]": "CharAtom",
           "Character": "x",
           "TextStyle": null,
           "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.colorModelsWithOpacity.(color (red, 0.1) x).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.colorModelsWithOpacity.(color (red, 0.1) x).approved.txt
@@ -1,10 +1,13 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "StyledAtom",
     "RowAtom": {
+      "[AtomType]": "RowAtom",
       "PreviousAtom": null,
       "Elements": [
         {
+          "[AtomType]": "CharAtom",
           "Character": "x",
           "TextStyle": null,
           "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.colorModelsWithOpacity.(color [ARGB] (25, 128, 128, 128) x).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.colorModelsWithOpacity.(color [ARGB] (25, 128, 128, 128) x).approved.txt
@@ -1,10 +1,13 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "StyledAtom",
     "RowAtom": {
+      "[AtomType]": "RowAtom",
       "PreviousAtom": null,
       "Elements": [
         {
+          "[AtomType]": "CharAtom",
           "Character": "x",
           "TextStyle": null,
           "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.colorModelsWithOpacity.(color [HTML] (abcdef19) x).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.colorModelsWithOpacity.(color [HTML] (abcdef19) x).approved.txt
@@ -1,10 +1,13 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "StyledAtom",
     "RowAtom": {
+      "[AtomType]": "RowAtom",
       "PreviousAtom": null,
       "Elements": [
         {
+          "[AtomType]": "CharAtom",
           "Character": "x",
           "TextStyle": null,
           "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.colorModelsWithOpacity.(color [RGBA] (128, 128, 128, 25) x).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.colorModelsWithOpacity.(color [RGBA] (128, 128, 128, 25) x).approved.txt
@@ -1,10 +1,13 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "StyledAtom",
     "RowAtom": {
+      "[AtomType]": "RowAtom",
       "PreviousAtom": null,
       "Elements": [
         {
+          "[AtomType]": "CharAtom",
           "Character": "x",
           "TextStyle": null,
           "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.colorModelsWithOpacity.(color [] (red, 0.1) x).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.colorModelsWithOpacity.(color [] (red, 0.1) x).approved.txt
@@ -1,10 +1,13 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "StyledAtom",
     "RowAtom": {
+      "[AtomType]": "RowAtom",
       "PreviousAtom": null,
       "Elements": [
         {
+          "[AtomType]": "CharAtom",
           "Character": "x",
           "TextStyle": null,
           "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.colorModelsWithOpacity.(color [argb] (0.1, 0.5, 0.5, 0.5) x).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.colorModelsWithOpacity.(color [argb] (0.1, 0.5, 0.5, 0.5) x).approved.txt
@@ -1,10 +1,13 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "StyledAtom",
     "RowAtom": {
+      "[AtomType]": "RowAtom",
       "PreviousAtom": null,
       "Elements": [
         {
+          "[AtomType]": "CharAtom",
           "Character": "x",
           "TextStyle": null,
           "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.colorModelsWithOpacity.(color [cmyk] (0.5, 0.5, 0.5, 0.5, 0.1) x).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.colorModelsWithOpacity.(color [cmyk] (0.5, 0.5, 0.5, 0.5, 0.1) x).approved.txt
@@ -1,10 +1,13 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "StyledAtom",
     "RowAtom": {
+      "[AtomType]": "RowAtom",
       "PreviousAtom": null,
       "Elements": [
         {
+          "[AtomType]": "CharAtom",
           "Character": "x",
           "TextStyle": null,
           "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.colorModelsWithOpacity.(color [gray] (0.5, 0.1) x).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.colorModelsWithOpacity.(color [gray] (0.5, 0.1) x).approved.txt
@@ -1,10 +1,13 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "StyledAtom",
     "RowAtom": {
+      "[AtomType]": "RowAtom",
       "PreviousAtom": null,
       "Elements": [
         {
+          "[AtomType]": "CharAtom",
           "Character": "x",
           "TextStyle": null,
           "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.colorModelsWithOpacity.(color [rgba] (0.5, 0.5, 0.5, 0.1) x).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.colorModelsWithOpacity.(color [rgba] (0.5, 0.5, 0.5, 0.1) x).approved.txt
@@ -1,10 +1,13 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "StyledAtom",
     "RowAtom": {
+      "[AtomType]": "RowAtom",
       "PreviousAtom": null,
       "Elements": [
         {
+          "[AtomType]": "CharAtom",
           "Character": "x",
           "TextStyle": null,
           "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.colorModelsWithOpacity.(colorbox (red, 0.1) x).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.colorModelsWithOpacity.(colorbox (red, 0.1) x).approved.txt
@@ -1,10 +1,13 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "StyledAtom",
     "RowAtom": {
+      "[AtomType]": "RowAtom",
       "PreviousAtom": null,
       "Elements": [
         {
+          "[AtomType]": "CharAtom",
           "Character": "x",
           "TextStyle": null,
           "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.colorModelsWithOpacity.(colorbox [ARGB] (25, 128, 128, 128) x).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.colorModelsWithOpacity.(colorbox [ARGB] (25, 128, 128, 128) x).approved.txt
@@ -1,10 +1,13 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "StyledAtom",
     "RowAtom": {
+      "[AtomType]": "RowAtom",
       "PreviousAtom": null,
       "Elements": [
         {
+          "[AtomType]": "CharAtom",
           "Character": "x",
           "TextStyle": null,
           "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.colorModelsWithOpacity.(colorbox [HTML] (abcdef19) x).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.colorModelsWithOpacity.(colorbox [HTML] (abcdef19) x).approved.txt
@@ -1,10 +1,13 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "StyledAtom",
     "RowAtom": {
+      "[AtomType]": "RowAtom",
       "PreviousAtom": null,
       "Elements": [
         {
+          "[AtomType]": "CharAtom",
           "Character": "x",
           "TextStyle": null,
           "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.colorModelsWithOpacity.(colorbox [RGBA] (128, 128, 128, 25) x).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.colorModelsWithOpacity.(colorbox [RGBA] (128, 128, 128, 25) x).approved.txt
@@ -1,10 +1,13 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "StyledAtom",
     "RowAtom": {
+      "[AtomType]": "RowAtom",
       "PreviousAtom": null,
       "Elements": [
         {
+          "[AtomType]": "CharAtom",
           "Character": "x",
           "TextStyle": null,
           "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.colorModelsWithOpacity.(colorbox [] (red, 0.1) x).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.colorModelsWithOpacity.(colorbox [] (red, 0.1) x).approved.txt
@@ -1,10 +1,13 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "StyledAtom",
     "RowAtom": {
+      "[AtomType]": "RowAtom",
       "PreviousAtom": null,
       "Elements": [
         {
+          "[AtomType]": "CharAtom",
           "Character": "x",
           "TextStyle": null,
           "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.colorModelsWithOpacity.(colorbox [argb] (0.1, 0.5, 0.5, 0.5) x).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.colorModelsWithOpacity.(colorbox [argb] (0.1, 0.5, 0.5, 0.5) x).approved.txt
@@ -1,10 +1,13 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "StyledAtom",
     "RowAtom": {
+      "[AtomType]": "RowAtom",
       "PreviousAtom": null,
       "Elements": [
         {
+          "[AtomType]": "CharAtom",
           "Character": "x",
           "TextStyle": null,
           "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.colorModelsWithOpacity.(colorbox [cmyk] (0.5, 0.5, 0.5, 0.5, 0.1) x).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.colorModelsWithOpacity.(colorbox [cmyk] (0.5, 0.5, 0.5, 0.5, 0.1) x).approved.txt
@@ -1,10 +1,13 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "StyledAtom",
     "RowAtom": {
+      "[AtomType]": "RowAtom",
       "PreviousAtom": null,
       "Elements": [
         {
+          "[AtomType]": "CharAtom",
           "Character": "x",
           "TextStyle": null,
           "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.colorModelsWithOpacity.(colorbox [gray] (0.5, 0.1) x).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.colorModelsWithOpacity.(colorbox [gray] (0.5, 0.1) x).approved.txt
@@ -1,10 +1,13 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "StyledAtom",
     "RowAtom": {
+      "[AtomType]": "RowAtom",
       "PreviousAtom": null,
       "Elements": [
         {
+          "[AtomType]": "CharAtom",
           "Character": "x",
           "TextStyle": null,
           "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.colorModelsWithOpacity.(colorbox [rgba] (0.5, 0.5, 0.5, 0.1) x).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.colorModelsWithOpacity.(colorbox [rgba] (0.5, 0.5, 0.5, 0.1) x).approved.txt
@@ -1,10 +1,13 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "StyledAtom",
     "RowAtom": {
+      "[AtomType]": "RowAtom",
       "PreviousAtom": null,
       "Elements": [
         {
+          "[AtomType]": "CharAtom",
           "Character": "x",
           "TextStyle": null,
           "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.colorbox.((red) (1)123).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.colorbox.((red) (1)123).approved.txt
@@ -1,13 +1,17 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "RowAtom",
     "PreviousAtom": null,
     "Elements": [
       {
+        "[AtomType]": "StyledAtom",
         "RowAtom": {
+          "[AtomType]": "RowAtom",
           "PreviousAtom": null,
           "Elements": [
             {
+              "[AtomType]": "CharAtom",
               "Character": "1",
               "TextStyle": null,
               "IsTextSymbol": false,
@@ -42,6 +46,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "1",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -55,6 +60,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "2",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -68,6 +74,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "3",
         "TextStyle": null,
         "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.colorbox.((red) 1123).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.colorbox.((red) 1123).approved.txt
@@ -1,13 +1,17 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "RowAtom",
     "PreviousAtom": null,
     "Elements": [
       {
+        "[AtomType]": "StyledAtom",
         "RowAtom": {
+          "[AtomType]": "RowAtom",
           "PreviousAtom": null,
           "Elements": [
             {
+              "[AtomType]": "CharAtom",
               "Character": "1",
               "TextStyle": null,
               "IsTextSymbol": false,
@@ -42,6 +46,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "1",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -55,6 +60,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "2",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -68,6 +74,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "3",
         "TextStyle": null,
         "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.colorbox.((red)(1)123).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.colorbox.((red)(1)123).approved.txt
@@ -1,13 +1,17 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "RowAtom",
     "PreviousAtom": null,
     "Elements": [
       {
+        "[AtomType]": "StyledAtom",
         "RowAtom": {
+          "[AtomType]": "RowAtom",
           "PreviousAtom": null,
           "Elements": [
             {
+              "[AtomType]": "CharAtom",
               "Character": "1",
               "TextStyle": null,
               "IsTextSymbol": false,
@@ -42,6 +46,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "1",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -55,6 +60,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "2",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -68,6 +74,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "3",
         "TextStyle": null,
         "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.colorbox.((red)1123).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.colorbox.((red)1123).approved.txt
@@ -1,13 +1,17 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "RowAtom",
     "PreviousAtom": null,
     "Elements": [
       {
+        "[AtomType]": "StyledAtom",
         "RowAtom": {
+          "[AtomType]": "RowAtom",
           "PreviousAtom": null,
           "Elements": [
             {
+              "[AtomType]": "CharAtom",
               "Character": "1",
               "TextStyle": null,
               "IsTextSymbol": false,
@@ -42,6 +46,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "1",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -55,6 +60,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "2",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -68,6 +74,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "3",
         "TextStyle": null,
         "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.commandsInText.approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.commandsInText.approved.txt
@@ -1,9 +1,11 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "RowAtom",
     "PreviousAtom": null,
     "Elements": [
       {
+        "[AtomType]": "CharAtom",
         "Character": "\\",
         "TextStyle": "text",
         "IsTextSymbol": false,
@@ -17,6 +19,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "a",
         "TextStyle": "text",
         "IsTextSymbol": false,
@@ -30,6 +33,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "l",
         "TextStyle": "text",
         "IsTextSymbol": false,
@@ -43,6 +47,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "p",
         "TextStyle": "text",
         "IsTextSymbol": false,
@@ -56,6 +61,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "h",
         "TextStyle": "text",
         "IsTextSymbol": false,
@@ -69,6 +75,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "a",
         "TextStyle": "text",
         "IsTextSymbol": false,
@@ -82,6 +89,7 @@
         }
       },
       {
+        "[AtomType]": "SpaceAtom",
         "Type": "Ordinary",
         "Source": {
           "Start": 12,
@@ -92,6 +100,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "\\",
         "TextStyle": "text",
         "IsTextSymbol": false,
@@ -105,6 +114,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "b",
         "TextStyle": "text",
         "IsTextSymbol": false,
@@ -118,6 +128,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "e",
         "TextStyle": "text",
         "IsTextSymbol": false,
@@ -131,6 +142,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "t",
         "TextStyle": "text",
         "IsTextSymbol": false,
@@ -144,6 +156,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "a",
         "TextStyle": "text",
         "IsTextSymbol": false,
@@ -157,6 +170,7 @@
         }
       },
       {
+        "[AtomType]": "SpaceAtom",
         "Type": "Ordinary",
         "Source": {
           "Start": 18,
@@ -167,6 +181,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "\\",
         "TextStyle": "text",
         "IsTextSymbol": false,
@@ -180,6 +195,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "u",
         "TextStyle": "text",
         "IsTextSymbol": false,
@@ -193,6 +209,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "n",
         "TextStyle": "text",
         "IsTextSymbol": false,
@@ -206,6 +223,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "k",
         "TextStyle": "text",
         "IsTextSymbol": false,
@@ -219,6 +237,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "n",
         "TextStyle": "text",
         "IsTextSymbol": false,
@@ -232,6 +251,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "o",
         "TextStyle": "text",
         "IsTextSymbol": false,
@@ -245,6 +265,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "w",
         "TextStyle": "text",
         "IsTextSymbol": false,
@@ -258,6 +279,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "n",
         "TextStyle": "text",
         "IsTextSymbol": false,
@@ -271,6 +293,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "c",
         "TextStyle": "text",
         "IsTextSymbol": false,
@@ -284,6 +307,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "o",
         "TextStyle": "text",
         "IsTextSymbol": false,
@@ -297,6 +321,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "m",
         "TextStyle": "text",
         "IsTextSymbol": false,
@@ -310,6 +335,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "m",
         "TextStyle": "text",
         "IsTextSymbol": false,
@@ -323,6 +349,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "a",
         "TextStyle": "text",
         "IsTextSymbol": false,
@@ -336,6 +363,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "n",
         "TextStyle": "text",
         "IsTextSymbol": false,
@@ -349,6 +377,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "d",
         "TextStyle": "text",
         "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.complexMathrm.approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.complexMathrm.approved.txt
@@ -1,13 +1,17 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "RowAtom",
     "PreviousAtom": null,
     "Elements": [
       {
+        "[AtomType]": "FencedAtom",
         "BaseAtom": {
+          "[AtomType]": "RowAtom",
           "PreviousAtom": null,
           "Elements": [
             {
+              "[AtomType]": "CharAtom",
               "Character": "2",
               "TextStyle": "mathrm",
               "IsTextSymbol": false,
@@ -21,6 +25,7 @@
               }
             },
             {
+              "[AtomType]": "SymbolAtom",
               "IsDelimeter": false,
               "Name": "plus",
               "IsTextSymbol": false,
@@ -34,6 +39,7 @@
               }
             },
             {
+              "[AtomType]": "CharAtom",
               "Character": "2",
               "TextStyle": "mathrm",
               "IsTextSymbol": false,
@@ -57,6 +63,7 @@
           }
         },
         "LeftDelimeter": {
+          "[AtomType]": "SymbolAtom",
           "IsDelimeter": true,
           "Name": "(",
           "IsTextSymbol": false,
@@ -70,6 +77,7 @@
           }
         },
         "RightDelimeter": {
+          "[AtomType]": "SymbolAtom",
           "IsDelimeter": true,
           "Name": ")",
           "IsTextSymbol": false,
@@ -92,6 +100,7 @@
         }
       },
       {
+        "[AtomType]": "SymbolAtom",
         "IsDelimeter": false,
         "Name": "plus",
         "IsTextSymbol": false,
@@ -105,6 +114,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "1",
         "TextStyle": null,
         "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.cyrillicText.approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.cyrillicText.approved.txt
@@ -1,9 +1,11 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "RowAtom",
     "PreviousAtom": null,
     "Elements": [
       {
+        "[AtomType]": "CharAtom",
         "Character": "а",
         "TextStyle": "text",
         "IsTextSymbol": false,
@@ -17,6 +19,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "б",
         "TextStyle": "text",
         "IsTextSymbol": false,
@@ -30,6 +33,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "в",
         "TextStyle": "text",
         "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.delimiterWithScripts.approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.delimiterWithScripts.approved.txt
@@ -1,11 +1,15 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "ScriptsAtom",
     "BaseAtom": {
+      "[AtomType]": "FencedAtom",
       "BaseAtom": {
+        "[AtomType]": "RowAtom",
         "PreviousAtom": null,
         "Elements": [
           {
+            "[AtomType]": "CharAtom",
             "Character": "2",
             "TextStyle": null,
             "IsTextSymbol": false,
@@ -19,6 +23,7 @@
             }
           },
           {
+            "[AtomType]": "SymbolAtom",
             "IsDelimeter": false,
             "Name": "plus",
             "IsTextSymbol": false,
@@ -32,6 +37,7 @@
             }
           },
           {
+            "[AtomType]": "CharAtom",
             "Character": "2",
             "TextStyle": null,
             "IsTextSymbol": false,
@@ -55,6 +61,7 @@
         }
       },
       "LeftDelimeter": {
+        "[AtomType]": "SymbolAtom",
         "IsDelimeter": true,
         "Name": "(",
         "IsTextSymbol": false,
@@ -68,6 +75,7 @@
         }
       },
       "RightDelimeter": {
+        "[AtomType]": "SymbolAtom",
         "IsDelimeter": true,
         "Name": ")",
         "IsTextSymbol": false,
@@ -90,6 +98,7 @@
       }
     },
     "SubscriptAtom": {
+      "[AtomType]": "CharAtom",
       "Character": "a",
       "TextStyle": null,
       "IsTextSymbol": false,
@@ -103,6 +112,7 @@
       }
     },
     "SuperscriptAtom": {
+      "[AtomType]": "CharAtom",
       "Character": "b",
       "TextStyle": null,
       "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.delimiters.((,)).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.delimiters.((,)).approved.txt
@@ -1,7 +1,9 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "FencedAtom",
     "BaseAtom": {
+      "[AtomType]": "CharAtom",
       "Character": "a",
       "TextStyle": null,
       "IsTextSymbol": false,
@@ -15,6 +17,7 @@
       }
     },
     "LeftDelimeter": {
+      "[AtomType]": "SymbolAtom",
       "IsDelimeter": true,
       "Name": "(",
       "IsTextSymbol": false,
@@ -28,6 +31,7 @@
       }
     },
     "RightDelimeter": {
+      "[AtomType]": "SymbolAtom",
       "IsDelimeter": true,
       "Name": ")",
       "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.delimiters.(backslash,backslash).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.delimiters.(backslash,backslash).approved.txt
@@ -1,7 +1,9 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "FencedAtom",
     "BaseAtom": {
+      "[AtomType]": "CharAtom",
       "Character": "a",
       "TextStyle": null,
       "IsTextSymbol": false,
@@ -15,6 +17,7 @@
       }
     },
     "LeftDelimeter": {
+      "[AtomType]": "SymbolAtom",
       "IsDelimeter": true,
       "Name": "backslash",
       "IsTextSymbol": false,
@@ -28,6 +31,7 @@
       }
     },
     "RightDelimeter": {
+      "[AtomType]": "SymbolAtom",
       "IsDelimeter": true,
       "Name": "backslash",
       "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.delimiters.(langle,rangle).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.delimiters.(langle,rangle).approved.txt
@@ -1,7 +1,9 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "FencedAtom",
     "BaseAtom": {
+      "[AtomType]": "CharAtom",
       "Character": "a",
       "TextStyle": null,
       "IsTextSymbol": false,
@@ -15,6 +17,7 @@
       }
     },
     "LeftDelimeter": {
+      "[AtomType]": "SymbolAtom",
       "IsDelimeter": true,
       "Name": "langle",
       "IsTextSymbol": false,
@@ -28,6 +31,7 @@
       }
     },
     "RightDelimeter": {
+      "[AtomType]": "SymbolAtom",
       "IsDelimeter": true,
       "Name": "rangle",
       "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.delimiters.(lbrace,rbrace).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.delimiters.(lbrace,rbrace).approved.txt
@@ -1,7 +1,9 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "FencedAtom",
     "BaseAtom": {
+      "[AtomType]": "CharAtom",
       "Character": "a",
       "TextStyle": null,
       "IsTextSymbol": false,
@@ -15,6 +17,7 @@
       }
     },
     "LeftDelimeter": {
+      "[AtomType]": "SymbolAtom",
       "IsDelimeter": true,
       "Name": "lbrace",
       "IsTextSymbol": false,
@@ -28,6 +31,7 @@
       }
     },
     "RightDelimeter": {
+      "[AtomType]": "SymbolAtom",
       "IsDelimeter": true,
       "Name": "rbrace",
       "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.delimiters.(lbrack,rbrack).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.delimiters.(lbrack,rbrack).approved.txt
@@ -1,7 +1,9 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "FencedAtom",
     "BaseAtom": {
+      "[AtomType]": "CharAtom",
       "Character": "a",
       "TextStyle": null,
       "IsTextSymbol": false,
@@ -15,6 +17,7 @@
       }
     },
     "LeftDelimeter": {
+      "[AtomType]": "SymbolAtom",
       "IsDelimeter": true,
       "Name": "lbrack",
       "IsTextSymbol": false,
@@ -28,6 +31,7 @@
       }
     },
     "RightDelimeter": {
+      "[AtomType]": "SymbolAtom",
       "IsDelimeter": true,
       "Name": "rbrack",
       "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.delimiters.(vert,vert).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.delimiters.(vert,vert).approved.txt
@@ -1,7 +1,9 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "FencedAtom",
     "BaseAtom": {
+      "[AtomType]": "CharAtom",
       "Character": "a",
       "TextStyle": null,
       "IsTextSymbol": false,
@@ -15,6 +17,7 @@
       }
     },
     "LeftDelimeter": {
+      "[AtomType]": "SymbolAtom",
       "IsDelimeter": true,
       "Name": "vert",
       "IsTextSymbol": false,
@@ -28,6 +31,7 @@
       }
     },
     "RightDelimeter": {
+      "[AtomType]": "SymbolAtom",
       "IsDelimeter": true,
       "Name": "vert",
       "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.emptyCurlyBraces.approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.emptyCurlyBraces.approved.txt
@@ -1,7 +1,9 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "TypedAtom",
     "Atom": {
+      "[AtomType]": "RowAtom",
       "PreviousAtom": null,
       "Elements": [],
       "Type": "Ordinary",

--- a/src/WpfMath.Tests/TestResults/ParserTests.emptyDelimiters.(((,.,false,true)).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.emptyDelimiters.(((,.,false,true)).approved.txt
@@ -1,7 +1,9 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "FencedAtom",
     "BaseAtom": {
+      "[AtomType]": "CharAtom",
       "Character": "a",
       "TextStyle": null,
       "IsTextSymbol": false,
@@ -15,6 +17,7 @@
       }
     },
     "LeftDelimeter": {
+      "[AtomType]": "SymbolAtom",
       "IsDelimeter": true,
       "Name": "(",
       "IsTextSymbol": false,
@@ -28,6 +31,7 @@
       }
     },
     "RightDelimeter": {
+      "[AtomType]": "SymbolAtom",
       "IsDelimeter": true,
       "Name": "_emptyDelimiter",
       "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.emptyDelimiters.((.,),true,false)).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.emptyDelimiters.((.,),true,false)).approved.txt
@@ -1,7 +1,9 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "FencedAtom",
     "BaseAtom": {
+      "[AtomType]": "CharAtom",
       "Character": "a",
       "TextStyle": null,
       "IsTextSymbol": false,
@@ -15,6 +17,7 @@
       }
     },
     "LeftDelimeter": {
+      "[AtomType]": "SymbolAtom",
       "IsDelimeter": true,
       "Name": "_emptyDelimiter",
       "IsTextSymbol": false,
@@ -28,6 +31,7 @@
       }
     },
     "RightDelimeter": {
+      "[AtomType]": "SymbolAtom",
       "IsDelimeter": true,
       "Name": ")",
       "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.expressionAfterBraces.approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.expressionAfterBraces.approved.txt
@@ -1,13 +1,17 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "RowAtom",
     "PreviousAtom": null,
     "Elements": [
       {
+        "[AtomType]": "FencedAtom",
         "BaseAtom": {
+          "[AtomType]": "RowAtom",
           "PreviousAtom": null,
           "Elements": [
             {
+              "[AtomType]": "CharAtom",
               "Character": "2",
               "TextStyle": null,
               "IsTextSymbol": false,
@@ -21,6 +25,7 @@
               }
             },
             {
+              "[AtomType]": "SymbolAtom",
               "IsDelimeter": false,
               "Name": "plus",
               "IsTextSymbol": false,
@@ -34,6 +39,7 @@
               }
             },
             {
+              "[AtomType]": "CharAtom",
               "Character": "2",
               "TextStyle": null,
               "IsTextSymbol": false,
@@ -57,6 +63,7 @@
           }
         },
         "LeftDelimeter": {
+          "[AtomType]": "SymbolAtom",
           "IsDelimeter": true,
           "Name": "(",
           "IsTextSymbol": false,
@@ -70,6 +77,7 @@
           }
         },
         "RightDelimeter": {
+          "[AtomType]": "SymbolAtom",
           "IsDelimeter": true,
           "Name": ")",
           "IsTextSymbol": false,
@@ -92,6 +100,7 @@
         }
       },
       {
+        "[AtomType]": "SymbolAtom",
         "IsDelimeter": false,
         "Name": "plus",
         "IsTextSymbol": false,
@@ -105,6 +114,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "1",
         "TextStyle": null,
         "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.expressionInBraces.approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.expressionInBraces.approved.txt
@@ -1,10 +1,13 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "FencedAtom",
     "BaseAtom": {
+      "[AtomType]": "RowAtom",
       "PreviousAtom": null,
       "Elements": [
         {
+          "[AtomType]": "CharAtom",
           "Character": "2",
           "TextStyle": null,
           "IsTextSymbol": false,
@@ -18,6 +21,7 @@
           }
         },
         {
+          "[AtomType]": "SymbolAtom",
           "IsDelimeter": false,
           "Name": "plus",
           "IsTextSymbol": false,
@@ -31,6 +35,7 @@
           }
         },
         {
+          "[AtomType]": "CharAtom",
           "Character": "2",
           "TextStyle": null,
           "IsTextSymbol": false,
@@ -54,6 +59,7 @@
       }
     },
     "LeftDelimeter": {
+      "[AtomType]": "SymbolAtom",
       "IsDelimeter": true,
       "Name": "(",
       "IsTextSymbol": false,
@@ -67,6 +73,7 @@
       }
     },
     "RightDelimeter": {
+      "[AtomType]": "SymbolAtom",
       "IsDelimeter": true,
       "Name": ")",
       "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.frac.( 2 x123).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.frac.( 2 x123).approved.txt
@@ -1,10 +1,13 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "RowAtom",
     "PreviousAtom": null,
     "Elements": [
       {
+        "[AtomType]": "FractionAtom",
         "Numerator": {
+          "[AtomType]": "CharAtom",
           "Character": "2",
           "TextStyle": null,
           "IsTextSymbol": false,
@@ -18,6 +21,7 @@
           }
         },
         "Denominator": {
+          "[AtomType]": "CharAtom",
           "Character": "x",
           "TextStyle": null,
           "IsTextSymbol": false,
@@ -40,6 +44,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "1",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -53,6 +58,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "2",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -66,6 +72,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "3",
         "TextStyle": null,
         "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.frac.( 2(x)123).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.frac.( 2(x)123).approved.txt
@@ -1,10 +1,13 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "RowAtom",
     "PreviousAtom": null,
     "Elements": [
       {
+        "[AtomType]": "FractionAtom",
         "Numerator": {
+          "[AtomType]": "CharAtom",
           "Character": "2",
           "TextStyle": null,
           "IsTextSymbol": false,
@@ -18,6 +21,7 @@
           }
         },
         "Denominator": {
+          "[AtomType]": "CharAtom",
           "Character": "x",
           "TextStyle": null,
           "IsTextSymbol": false,
@@ -40,6 +44,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "1",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -53,6 +58,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "2",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -66,6 +72,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "3",
         "TextStyle": null,
         "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.frac.((2)(x)123).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.frac.((2)(x)123).approved.txt
@@ -1,10 +1,13 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "RowAtom",
     "PreviousAtom": null,
     "Elements": [
       {
+        "[AtomType]": "FractionAtom",
         "Numerator": {
+          "[AtomType]": "CharAtom",
           "Character": "2",
           "TextStyle": null,
           "IsTextSymbol": false,
@@ -18,6 +21,7 @@
           }
         },
         "Denominator": {
+          "[AtomType]": "CharAtom",
           "Character": "x",
           "TextStyle": null,
           "IsTextSymbol": false,
@@ -40,6 +44,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "1",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -53,6 +58,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "2",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -66,6 +72,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "3",
         "TextStyle": null,
         "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.frac.((2)x123).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.frac.((2)x123).approved.txt
@@ -1,10 +1,13 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "RowAtom",
     "PreviousAtom": null,
     "Elements": [
       {
+        "[AtomType]": "FractionAtom",
         "Numerator": {
+          "[AtomType]": "CharAtom",
           "Character": "2",
           "TextStyle": null,
           "IsTextSymbol": false,
@@ -18,6 +21,7 @@
           }
         },
         "Denominator": {
+          "[AtomType]": "CharAtom",
           "Character": "x",
           "TextStyle": null,
           "IsTextSymbol": false,
@@ -40,6 +44,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "1",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -53,6 +58,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "2",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -66,6 +72,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "3",
         "TextStyle": null,
         "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.frac.(2 (x)123).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.frac.(2 (x)123).approved.txt
@@ -1,10 +1,13 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "RowAtom",
     "PreviousAtom": null,
     "Elements": [
       {
+        "[AtomType]": "FractionAtom",
         "Numerator": {
+          "[AtomType]": "CharAtom",
           "Character": "2",
           "TextStyle": null,
           "IsTextSymbol": false,
@@ -18,6 +21,7 @@
           }
         },
         "Denominator": {
+          "[AtomType]": "CharAtom",
           "Character": "x",
           "TextStyle": null,
           "IsTextSymbol": false,
@@ -40,6 +44,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "1",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -53,6 +58,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "2",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -66,6 +72,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "3",
         "TextStyle": null,
         "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.frac.(2(x)123).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.frac.(2(x)123).approved.txt
@@ -1,10 +1,13 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "RowAtom",
     "PreviousAtom": null,
     "Elements": [
       {
+        "[AtomType]": "FractionAtom",
         "Numerator": {
+          "[AtomType]": "CharAtom",
           "Character": "2",
           "TextStyle": null,
           "IsTextSymbol": false,
@@ -18,6 +21,7 @@
           }
         },
         "Denominator": {
+          "[AtomType]": "CharAtom",
           "Character": "x",
           "TextStyle": null,
           "IsTextSymbol": false,
@@ -40,6 +44,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "1",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -53,6 +58,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "2",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -66,6 +72,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "3",
         "TextStyle": null,
         "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.frac.(2x123).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.frac.(2x123).approved.txt
@@ -1,10 +1,13 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "RowAtom",
     "PreviousAtom": null,
     "Elements": [
       {
+        "[AtomType]": "FractionAtom",
         "Numerator": {
+          "[AtomType]": "CharAtom",
           "Character": "2",
           "TextStyle": null,
           "IsTextSymbol": false,
@@ -18,6 +21,7 @@
           }
         },
         "Denominator": {
+          "[AtomType]": "CharAtom",
           "Character": "x",
           "TextStyle": null,
           "IsTextSymbol": false,
@@ -40,6 +44,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "1",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -53,6 +58,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "2",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -66,6 +72,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "3",
         "TextStyle": null,
         "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.hat.approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.hat.approved.txt
@@ -1,8 +1,11 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "TypedAtom",
     "Atom": {
+      "[AtomType]": "AccentedAtom",
       "BaseAtom": {
+        "[AtomType]": "CharAtom",
         "Character": "T",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -16,6 +19,7 @@
         }
       },
       "AccentAtom": {
+        "[AtomType]": "SymbolAtom",
         "IsDelimeter": false,
         "Name": "hat",
         "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.intF.approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.intF.approved.txt
@@ -1,10 +1,13 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "RowAtom",
     "PreviousAtom": null,
     "Elements": [
       {
+        "[AtomType]": "BigOperatorAtom",
         "BaseAtom": {
+          "[AtomType]": "SymbolAtom",
           "IsDelimeter": false,
           "Name": "int",
           "IsTextSymbol": false,
@@ -30,6 +33,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "f",
         "TextStyle": null,
         "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.integral.approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.integral.approved.txt
@@ -1,7 +1,9 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "BigOperatorAtom",
     "BaseAtom": {
+      "[AtomType]": "SymbolAtom",
       "IsDelimeter": false,
       "Name": "int",
       "IsTextSymbol": false,
@@ -15,6 +17,7 @@
       }
     },
     "LowerLimitAtom": {
+      "[AtomType]": "CharAtom",
       "Character": "a",
       "TextStyle": null,
       "IsTextSymbol": false,
@@ -28,6 +31,7 @@
       }
     },
     "UpperLimitAtom": {
+      "[AtomType]": "CharAtom",
       "Character": "b",
       "TextStyle": null,
       "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.lim.approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.lim.approved.txt
@@ -1,13 +1,17 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "RowAtom",
     "PreviousAtom": null,
     "Elements": [
       {
+        "[AtomType]": "BigOperatorAtom",
         "BaseAtom": {
+          "[AtomType]": "RowAtom",
           "PreviousAtom": null,
           "Elements": [
             {
+              "[AtomType]": "CharAtom",
               "Character": "l",
               "TextStyle": "mathrm",
               "IsTextSymbol": false,
@@ -21,6 +25,7 @@
               }
             },
             {
+              "[AtomType]": "CharAtom",
               "Character": "i",
               "TextStyle": "mathrm",
               "IsTextSymbol": false,
@@ -34,6 +39,7 @@
               }
             },
             {
+              "[AtomType]": "CharAtom",
               "Character": "m",
               "TextStyle": "mathrm",
               "IsTextSymbol": false,
@@ -57,6 +63,7 @@
           }
         },
         "LowerLimitAtom": {
+          "[AtomType]": "CharAtom",
           "Character": "n",
           "TextStyle": null,
           "IsTextSymbol": false,
@@ -81,6 +88,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "x",
         "TextStyle": null,
         "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.limInCurlyBraces.approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.limInCurlyBraces.approved.txt
@@ -1,14 +1,19 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "RowAtom",
     "PreviousAtom": null,
     "Elements": [
       {
+        "[AtomType]": "TypedAtom",
         "Atom": {
+          "[AtomType]": "BigOperatorAtom",
           "BaseAtom": {
+            "[AtomType]": "RowAtom",
             "PreviousAtom": null,
             "Elements": [
               {
+                "[AtomType]": "CharAtom",
                 "Character": "l",
                 "TextStyle": "mathrm",
                 "IsTextSymbol": false,
@@ -22,6 +27,7 @@
                 }
               },
               {
+                "[AtomType]": "CharAtom",
                 "Character": "i",
                 "TextStyle": "mathrm",
                 "IsTextSymbol": false,
@@ -35,6 +41,7 @@
                 }
               },
               {
+                "[AtomType]": "CharAtom",
                 "Character": "m",
                 "TextStyle": "mathrm",
                 "IsTextSymbol": false,
@@ -81,6 +88,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "x",
         "TextStyle": null,
         "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.mathcal.approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.mathcal.approved.txt
@@ -1,9 +1,11 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "RowAtom",
     "PreviousAtom": null,
     "Elements": [
       {
+        "[AtomType]": "CharAtom",
         "Character": "s",
         "TextStyle": "mathcal",
         "IsTextSymbol": false,
@@ -17,6 +19,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "i",
         "TextStyle": "mathcal",
         "IsTextSymbol": false,
@@ -30,6 +33,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "n",
         "TextStyle": "mathcal",
         "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.mathit.approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.mathit.approved.txt
@@ -1,9 +1,11 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "RowAtom",
     "PreviousAtom": null,
     "Elements": [
       {
+        "[AtomType]": "CharAtom",
         "Character": "s",
         "TextStyle": "mathit",
         "IsTextSymbol": false,
@@ -17,6 +19,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "i",
         "TextStyle": "mathit",
         "IsTextSymbol": false,
@@ -30,6 +33,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "n",
         "TextStyle": "mathit",
         "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.mathrm.approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.mathrm.approved.txt
@@ -1,9 +1,11 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "RowAtom",
     "PreviousAtom": null,
     "Elements": [
       {
+        "[AtomType]": "CharAtom",
         "Character": "s",
         "TextStyle": "mathrm",
         "IsTextSymbol": false,
@@ -17,6 +19,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "i",
         "TextStyle": "mathrm",
         "IsTextSymbol": false,
@@ -30,6 +33,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "n",
         "TextStyle": "mathrm",
         "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.matrixExpression.approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.matrixExpression.approved.txt
@@ -1,9 +1,11 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "RowAtom",
     "PreviousAtom": null,
     "Elements": [
       {
+        "[AtomType]": "CharAtom",
         "Character": "v",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -17,6 +19,7 @@
         }
       },
       {
+        "[AtomType]": "SymbolAtom",
         "IsDelimeter": false,
         "Name": "times",
         "IsTextSymbol": false,
@@ -30,6 +33,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "w",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -43,6 +47,7 @@
         }
       },
       {
+        "[AtomType]": "SymbolAtom",
         "IsDelimeter": false,
         "Name": "equals",
         "IsTextSymbol": false,
@@ -56,14 +61,19 @@
         }
       },
       {
+        "[AtomType]": "FencedAtom",
         "BaseAtom": {
+          "[AtomType]": "MatrixAtom",
           "MatrixCells": [
             [
               {
+                "[AtomType]": "RowAtom",
                 "PreviousAtom": null,
                 "Elements": [
                   {
+                    "[AtomType]": "ScriptsAtom",
                     "BaseAtom": {
+                      "[AtomType]": "CharAtom",
                       "Character": "v",
                       "TextStyle": null,
                       "IsTextSymbol": false,
@@ -77,6 +87,7 @@
                       }
                     },
                     "SubscriptAtom": {
+                      "[AtomType]": "CharAtom",
                       "Character": "2",
                       "TextStyle": null,
                       "IsTextSymbol": false,
@@ -100,7 +111,9 @@
                     }
                   },
                   {
+                    "[AtomType]": "ScriptsAtom",
                     "BaseAtom": {
+                      "[AtomType]": "CharAtom",
                       "Character": "w",
                       "TextStyle": null,
                       "IsTextSymbol": false,
@@ -114,6 +127,7 @@
                       }
                     },
                     "SubscriptAtom": {
+                      "[AtomType]": "CharAtom",
                       "Character": "3",
                       "TextStyle": null,
                       "IsTextSymbol": false,
@@ -137,6 +151,7 @@
                     }
                   },
                   {
+                    "[AtomType]": "SymbolAtom",
                     "IsDelimeter": false,
                     "Name": "minus",
                     "IsTextSymbol": false,
@@ -150,7 +165,9 @@
                     }
                   },
                   {
+                    "[AtomType]": "ScriptsAtom",
                     "BaseAtom": {
+                      "[AtomType]": "CharAtom",
                       "Character": "v",
                       "TextStyle": null,
                       "IsTextSymbol": false,
@@ -164,6 +181,7 @@
                       }
                     },
                     "SubscriptAtom": {
+                      "[AtomType]": "CharAtom",
                       "Character": "3",
                       "TextStyle": null,
                       "IsTextSymbol": false,
@@ -187,7 +205,9 @@
                     }
                   },
                   {
+                    "[AtomType]": "ScriptsAtom",
                     "BaseAtom": {
+                      "[AtomType]": "CharAtom",
                       "Character": "w",
                       "TextStyle": null,
                       "IsTextSymbol": false,
@@ -201,6 +221,7 @@
                       }
                     },
                     "SubscriptAtom": {
+                      "[AtomType]": "CharAtom",
                       "Character": "2",
                       "TextStyle": null,
                       "IsTextSymbol": false,
@@ -236,10 +257,13 @@
             ],
             [
               {
+                "[AtomType]": "RowAtom",
                 "PreviousAtom": null,
                 "Elements": [
                   {
+                    "[AtomType]": "ScriptsAtom",
                     "BaseAtom": {
+                      "[AtomType]": "CharAtom",
                       "Character": "v",
                       "TextStyle": null,
                       "IsTextSymbol": false,
@@ -253,6 +277,7 @@
                       }
                     },
                     "SubscriptAtom": {
+                      "[AtomType]": "CharAtom",
                       "Character": "3",
                       "TextStyle": null,
                       "IsTextSymbol": false,
@@ -276,7 +301,9 @@
                     }
                   },
                   {
+                    "[AtomType]": "ScriptsAtom",
                     "BaseAtom": {
+                      "[AtomType]": "CharAtom",
                       "Character": "w",
                       "TextStyle": null,
                       "IsTextSymbol": false,
@@ -290,6 +317,7 @@
                       }
                     },
                     "SubscriptAtom": {
+                      "[AtomType]": "CharAtom",
                       "Character": "1",
                       "TextStyle": null,
                       "IsTextSymbol": false,
@@ -313,6 +341,7 @@
                     }
                   },
                   {
+                    "[AtomType]": "SymbolAtom",
                     "IsDelimeter": false,
                     "Name": "minus",
                     "IsTextSymbol": false,
@@ -326,7 +355,9 @@
                     }
                   },
                   {
+                    "[AtomType]": "ScriptsAtom",
                     "BaseAtom": {
+                      "[AtomType]": "CharAtom",
                       "Character": "v",
                       "TextStyle": null,
                       "IsTextSymbol": false,
@@ -340,6 +371,7 @@
                       }
                     },
                     "SubscriptAtom": {
+                      "[AtomType]": "CharAtom",
                       "Character": "1",
                       "TextStyle": null,
                       "IsTextSymbol": false,
@@ -363,7 +395,9 @@
                     }
                   },
                   {
+                    "[AtomType]": "ScriptsAtom",
                     "BaseAtom": {
+                      "[AtomType]": "CharAtom",
                       "Character": "w",
                       "TextStyle": null,
                       "IsTextSymbol": false,
@@ -377,6 +411,7 @@
                       }
                     },
                     "SubscriptAtom": {
+                      "[AtomType]": "CharAtom",
                       "Character": "3",
                       "TextStyle": null,
                       "IsTextSymbol": false,
@@ -412,10 +447,13 @@
             ],
             [
               {
+                "[AtomType]": "RowAtom",
                 "PreviousAtom": null,
                 "Elements": [
                   {
+                    "[AtomType]": "ScriptsAtom",
                     "BaseAtom": {
+                      "[AtomType]": "CharAtom",
                       "Character": "v",
                       "TextStyle": null,
                       "IsTextSymbol": false,
@@ -429,6 +467,7 @@
                       }
                     },
                     "SubscriptAtom": {
+                      "[AtomType]": "CharAtom",
                       "Character": "1",
                       "TextStyle": null,
                       "IsTextSymbol": false,
@@ -452,7 +491,9 @@
                     }
                   },
                   {
+                    "[AtomType]": "ScriptsAtom",
                     "BaseAtom": {
+                      "[AtomType]": "CharAtom",
                       "Character": "w",
                       "TextStyle": null,
                       "IsTextSymbol": false,
@@ -466,6 +507,7 @@
                       }
                     },
                     "SubscriptAtom": {
+                      "[AtomType]": "CharAtom",
                       "Character": "2",
                       "TextStyle": null,
                       "IsTextSymbol": false,
@@ -489,6 +531,7 @@
                     }
                   },
                   {
+                    "[AtomType]": "SymbolAtom",
                     "IsDelimeter": false,
                     "Name": "minus",
                     "IsTextSymbol": false,
@@ -502,7 +545,9 @@
                     }
                   },
                   {
+                    "[AtomType]": "ScriptsAtom",
                     "BaseAtom": {
+                      "[AtomType]": "CharAtom",
                       "Character": "v",
                       "TextStyle": null,
                       "IsTextSymbol": false,
@@ -516,6 +561,7 @@
                       }
                     },
                     "SubscriptAtom": {
+                      "[AtomType]": "CharAtom",
                       "Character": "2",
                       "TextStyle": null,
                       "IsTextSymbol": false,
@@ -539,7 +585,9 @@
                     }
                   },
                   {
+                    "[AtomType]": "ScriptsAtom",
                     "BaseAtom": {
+                      "[AtomType]": "CharAtom",
                       "Character": "w",
                       "TextStyle": null,
                       "IsTextSymbol": false,
@@ -553,6 +601,7 @@
                       }
                     },
                     "SubscriptAtom": {
+                      "[AtomType]": "CharAtom",
                       "Character": "1",
                       "TextStyle": null,
                       "IsTextSymbol": false,
@@ -600,6 +649,7 @@
           }
         },
         "LeftDelimeter": {
+          "[AtomType]": "SymbolAtom",
           "IsDelimeter": true,
           "Name": "(",
           "IsTextSymbol": false,
@@ -613,6 +663,7 @@
           }
         },
         "RightDelimeter": {
+          "[AtomType]": "SymbolAtom",
           "IsDelimeter": true,
           "Name": ")",
           "IsTextSymbol": false,
@@ -635,6 +686,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "w",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -648,6 +700,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "h",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -661,6 +714,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "e",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -674,6 +728,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "r",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -687,6 +742,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "e",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -700,6 +756,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "v",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -713,6 +770,7 @@
         }
       },
       {
+        "[AtomType]": "SymbolAtom",
         "IsDelimeter": false,
         "Name": "equals",
         "IsTextSymbol": false,
@@ -726,11 +784,15 @@
         }
       },
       {
+        "[AtomType]": "FencedAtom",
         "BaseAtom": {
+          "[AtomType]": "MatrixAtom",
           "MatrixCells": [
             [
               {
+                "[AtomType]": "ScriptsAtom",
                 "BaseAtom": {
+                  "[AtomType]": "CharAtom",
                   "Character": "v",
                   "TextStyle": null,
                   "IsTextSymbol": false,
@@ -744,6 +806,7 @@
                   }
                 },
                 "SubscriptAtom": {
+                  "[AtomType]": "CharAtom",
                   "Character": "1",
                   "TextStyle": null,
                   "IsTextSymbol": false,
@@ -769,7 +832,9 @@
             ],
             [
               {
+                "[AtomType]": "ScriptsAtom",
                 "BaseAtom": {
+                  "[AtomType]": "CharAtom",
                   "Character": "v",
                   "TextStyle": null,
                   "IsTextSymbol": false,
@@ -783,6 +848,7 @@
                   }
                 },
                 "SubscriptAtom": {
+                  "[AtomType]": "CharAtom",
                   "Character": "2",
                   "TextStyle": null,
                   "IsTextSymbol": false,
@@ -808,7 +874,9 @@
             ],
             [
               {
+                "[AtomType]": "ScriptsAtom",
                 "BaseAtom": {
+                  "[AtomType]": "CharAtom",
                   "Character": "v",
                   "TextStyle": null,
                   "IsTextSymbol": false,
@@ -822,6 +890,7 @@
                   }
                 },
                 "SubscriptAtom": {
+                  "[AtomType]": "CharAtom",
                   "Character": "3",
                   "TextStyle": null,
                   "IsTextSymbol": false,
@@ -859,6 +928,7 @@
           }
         },
         "LeftDelimeter": {
+          "[AtomType]": "SymbolAtom",
           "IsDelimeter": true,
           "Name": "(",
           "IsTextSymbol": false,
@@ -872,6 +942,7 @@
           }
         },
         "RightDelimeter": {
+          "[AtomType]": "SymbolAtom",
           "IsDelimeter": true,
           "Name": ")",
           "IsTextSymbol": false,
@@ -894,6 +965,7 @@
         }
       },
       {
+        "[AtomType]": "SymbolAtom",
         "IsDelimeter": false,
         "Name": "comma",
         "IsTextSymbol": false,
@@ -907,6 +979,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "w",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -920,6 +993,7 @@
         }
       },
       {
+        "[AtomType]": "SymbolAtom",
         "IsDelimeter": false,
         "Name": "equals",
         "IsTextSymbol": false,
@@ -933,11 +1007,15 @@
         }
       },
       {
+        "[AtomType]": "FencedAtom",
         "BaseAtom": {
+          "[AtomType]": "MatrixAtom",
           "MatrixCells": [
             [
               {
+                "[AtomType]": "ScriptsAtom",
                 "BaseAtom": {
+                  "[AtomType]": "CharAtom",
                   "Character": "w",
                   "TextStyle": null,
                   "IsTextSymbol": false,
@@ -951,6 +1029,7 @@
                   }
                 },
                 "SubscriptAtom": {
+                  "[AtomType]": "CharAtom",
                   "Character": "1",
                   "TextStyle": null,
                   "IsTextSymbol": false,
@@ -976,7 +1055,9 @@
             ],
             [
               {
+                "[AtomType]": "ScriptsAtom",
                 "BaseAtom": {
+                  "[AtomType]": "CharAtom",
                   "Character": "w",
                   "TextStyle": null,
                   "IsTextSymbol": false,
@@ -990,6 +1071,7 @@
                   }
                 },
                 "SubscriptAtom": {
+                  "[AtomType]": "CharAtom",
                   "Character": "2",
                   "TextStyle": null,
                   "IsTextSymbol": false,
@@ -1015,7 +1097,9 @@
             ],
             [
               {
+                "[AtomType]": "ScriptsAtom",
                 "BaseAtom": {
+                  "[AtomType]": "CharAtom",
                   "Character": "w",
                   "TextStyle": null,
                   "IsTextSymbol": false,
@@ -1029,6 +1113,7 @@
                   }
                 },
                 "SubscriptAtom": {
+                  "[AtomType]": "CharAtom",
                   "Character": "3",
                   "TextStyle": null,
                   "IsTextSymbol": false,
@@ -1066,6 +1151,7 @@
           }
         },
         "LeftDelimeter": {
+          "[AtomType]": "SymbolAtom",
           "IsDelimeter": true,
           "Name": "(",
           "IsTextSymbol": false,
@@ -1079,6 +1165,7 @@
           }
         },
         "RightDelimeter": {
+          "[AtomType]": "SymbolAtom",
           "IsDelimeter": true,
           "Name": ")",
           "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.multilineFormula.approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.multilineFormula.approved.txt
@@ -1,12 +1,15 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "MatrixAtom",
     "MatrixCells": [
       [
         {
+          "[AtomType]": "RowAtom",
           "PreviousAtom": null,
           "Elements": [
             {
+              "[AtomType]": "CharAtom",
               "Character": "l",
               "TextStyle": null,
               "IsTextSymbol": false,
@@ -20,6 +23,7 @@
               }
             },
             {
+              "[AtomType]": "CharAtom",
               "Character": "i",
               "TextStyle": null,
               "IsTextSymbol": false,
@@ -33,6 +37,7 @@
               }
             },
             {
+              "[AtomType]": "CharAtom",
               "Character": "n",
               "TextStyle": null,
               "IsTextSymbol": false,
@@ -46,6 +51,7 @@
               }
             },
             {
+              "[AtomType]": "CharAtom",
               "Character": "e",
               "TextStyle": null,
               "IsTextSymbol": false,
@@ -59,6 +65,7 @@
               }
             },
             {
+              "[AtomType]": "CharAtom",
               "Character": "1",
               "TextStyle": null,
               "IsTextSymbol": false,
@@ -84,9 +91,11 @@
       ],
       [
         {
+          "[AtomType]": "RowAtom",
           "PreviousAtom": null,
           "Elements": [
             {
+              "[AtomType]": "CharAtom",
               "Character": "l",
               "TextStyle": null,
               "IsTextSymbol": false,
@@ -100,6 +109,7 @@
               }
             },
             {
+              "[AtomType]": "CharAtom",
               "Character": "i",
               "TextStyle": null,
               "IsTextSymbol": false,
@@ -113,6 +123,7 @@
               }
             },
             {
+              "[AtomType]": "CharAtom",
               "Character": "n",
               "TextStyle": null,
               "IsTextSymbol": false,
@@ -126,6 +137,7 @@
               }
             },
             {
+              "[AtomType]": "CharAtom",
               "Character": "e",
               "TextStyle": null,
               "IsTextSymbol": false,
@@ -139,6 +151,7 @@
               }
             },
             {
+              "[AtomType]": "CharAtom",
               "Character": "2",
               "TextStyle": null,
               "IsTextSymbol": false,
@@ -164,9 +177,11 @@
       ],
       [
         {
+          "[AtomType]": "RowAtom",
           "PreviousAtom": null,
           "Elements": [
             {
+              "[AtomType]": "CharAtom",
               "Character": "l",
               "TextStyle": null,
               "IsTextSymbol": false,
@@ -180,6 +195,7 @@
               }
             },
             {
+              "[AtomType]": "CharAtom",
               "Character": "i",
               "TextStyle": null,
               "IsTextSymbol": false,
@@ -193,6 +209,7 @@
               }
             },
             {
+              "[AtomType]": "CharAtom",
               "Character": "n",
               "TextStyle": null,
               "IsTextSymbol": false,
@@ -206,6 +223,7 @@
               }
             },
             {
+              "[AtomType]": "CharAtom",
               "Character": "e",
               "TextStyle": null,
               "IsTextSymbol": false,
@@ -219,6 +237,7 @@
               }
             },
             {
+              "[AtomType]": "CharAtom",
               "Character": "3",
               "TextStyle": null,
               "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.nestedMatrix.approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.nestedMatrix.approved.txt
@@ -1,9 +1,11 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "MatrixAtom",
     "MatrixCells": [
       [
         {
+          "[AtomType]": "CharAtom",
           "Character": "4",
           "TextStyle": null,
           "IsTextSymbol": false,
@@ -17,9 +19,11 @@
           }
         },
         {
+          "[AtomType]": "RowAtom",
           "PreviousAtom": null,
           "Elements": [
             {
+              "[AtomType]": "CharAtom",
               "Character": "7",
               "TextStyle": null,
               "IsTextSymbol": false,
@@ -33,6 +37,7 @@
               }
             },
             {
+              "[AtomType]": "CharAtom",
               "Character": "8",
               "TextStyle": null,
               "IsTextSymbol": false,
@@ -56,6 +61,7 @@
           }
         },
         {
+          "[AtomType]": "CharAtom",
           "Character": "3",
           "TextStyle": null,
           "IsTextSymbol": false,
@@ -71,9 +77,11 @@
       ],
       [
         {
+          "[AtomType]": "RowAtom",
           "PreviousAtom": null,
           "Elements": [
             {
+              "[AtomType]": "CharAtom",
               "Character": "5",
               "TextStyle": null,
               "IsTextSymbol": false,
@@ -87,6 +95,7 @@
               }
             },
             {
+              "[AtomType]": "CharAtom",
               "Character": "7",
               "TextStyle": null,
               "IsTextSymbol": false,
@@ -110,13 +119,17 @@
           }
         },
         {
+          "[AtomType]": "TypedAtom",
           "Atom": {
+            "[AtomType]": "MatrixAtom",
             "MatrixCells": [
               [
                 {
+                  "[AtomType]": "RowAtom",
                   "PreviousAtom": null,
                   "Elements": [
                     {
+                      "[AtomType]": "CharAtom",
                       "Character": "7",
                       "TextStyle": null,
                       "IsTextSymbol": false,
@@ -130,6 +143,7 @@
                       }
                     },
                     {
+                      "[AtomType]": "CharAtom",
                       "Character": "8",
                       "TextStyle": null,
                       "IsTextSymbol": false,
@@ -155,9 +169,11 @@
               ],
               [
                 {
+                  "[AtomType]": "RowAtom",
                   "PreviousAtom": null,
                   "Elements": [
                     {
+                      "[AtomType]": "CharAtom",
                       "Character": "1",
                       "TextStyle": null,
                       "IsTextSymbol": false,
@@ -171,6 +187,7 @@
                       }
                     },
                     {
+                      "[AtomType]": "CharAtom",
                       "Character": "2",
                       "TextStyle": null,
                       "IsTextSymbol": false,
@@ -219,9 +236,11 @@
           }
         },
         {
+          "[AtomType]": "RowAtom",
           "PreviousAtom": null,
           "Elements": [
             {
+              "[AtomType]": "CharAtom",
               "Character": "2",
               "TextStyle": null,
               "IsTextSymbol": false,
@@ -235,6 +254,7 @@
               }
             },
             {
+              "[AtomType]": "CharAtom",
               "Character": "0",
               "TextStyle": null,
               "IsTextSymbol": false,
@@ -248,6 +268,7 @@
               }
             },
             {
+              "[AtomType]": "CharAtom",
               "Character": "7",
               "TextStyle": null,
               "IsTextSymbol": false,
@@ -261,6 +282,7 @@
               }
             },
             {
+              "[AtomType]": "CharAtom",
               "Character": "8",
               "TextStyle": null,
               "IsTextSymbol": false,
@@ -274,6 +296,7 @@
               }
             },
             {
+              "[AtomType]": "CharAtom",
               "Character": "2",
               "TextStyle": null,
               "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.newLineAfterMatrix.(matrix(line 1)line 2).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.newLineAfterMatrix.(matrix(line 1)line 2).approved.txt
@@ -1,15 +1,19 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "MatrixAtom",
     "MatrixCells": [
       [
         {
+          "[AtomType]": "MatrixAtom",
           "MatrixCells": [
             [
               {
+                "[AtomType]": "RowAtom",
                 "PreviousAtom": null,
                 "Elements": [
                   {
+                    "[AtomType]": "CharAtom",
                     "Character": "l",
                     "TextStyle": null,
                     "IsTextSymbol": false,
@@ -23,6 +27,7 @@
                     }
                   },
                   {
+                    "[AtomType]": "CharAtom",
                     "Character": "i",
                     "TextStyle": null,
                     "IsTextSymbol": false,
@@ -36,6 +41,7 @@
                     }
                   },
                   {
+                    "[AtomType]": "CharAtom",
                     "Character": "n",
                     "TextStyle": null,
                     "IsTextSymbol": false,
@@ -49,6 +55,7 @@
                     }
                   },
                   {
+                    "[AtomType]": "CharAtom",
                     "Character": "e",
                     "TextStyle": null,
                     "IsTextSymbol": false,
@@ -62,6 +69,7 @@
                     }
                   },
                   {
+                    "[AtomType]": "CharAtom",
                     "Character": "1",
                     "TextStyle": null,
                     "IsTextSymbol": false,
@@ -101,9 +109,11 @@
       ],
       [
         {
+          "[AtomType]": "RowAtom",
           "PreviousAtom": null,
           "Elements": [
             {
+              "[AtomType]": "CharAtom",
               "Character": "l",
               "TextStyle": null,
               "IsTextSymbol": false,
@@ -117,6 +127,7 @@
               }
             },
             {
+              "[AtomType]": "CharAtom",
               "Character": "i",
               "TextStyle": null,
               "IsTextSymbol": false,
@@ -130,6 +141,7 @@
               }
             },
             {
+              "[AtomType]": "CharAtom",
               "Character": "n",
               "TextStyle": null,
               "IsTextSymbol": false,
@@ -143,6 +155,7 @@
               }
             },
             {
+              "[AtomType]": "CharAtom",
               "Character": "e",
               "TextStyle": null,
               "IsTextSymbol": false,
@@ -156,6 +169,7 @@
               }
             },
             {
+              "[AtomType]": "CharAtom",
               "Character": "2",
               "TextStyle": null,
               "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.newLineAfterMatrix.(pmatrix(line 1)line 2).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.newLineAfterMatrix.(pmatrix(line 1)line 2).approved.txt
@@ -1,16 +1,21 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "MatrixAtom",
     "MatrixCells": [
       [
         {
+          "[AtomType]": "FencedAtom",
           "BaseAtom": {
+            "[AtomType]": "MatrixAtom",
             "MatrixCells": [
               [
                 {
+                  "[AtomType]": "RowAtom",
                   "PreviousAtom": null,
                   "Elements": [
                     {
+                      "[AtomType]": "CharAtom",
                       "Character": "l",
                       "TextStyle": null,
                       "IsTextSymbol": false,
@@ -24,6 +29,7 @@
                       }
                     },
                     {
+                      "[AtomType]": "CharAtom",
                       "Character": "i",
                       "TextStyle": null,
                       "IsTextSymbol": false,
@@ -37,6 +43,7 @@
                       }
                     },
                     {
+                      "[AtomType]": "CharAtom",
                       "Character": "n",
                       "TextStyle": null,
                       "IsTextSymbol": false,
@@ -50,6 +57,7 @@
                       }
                     },
                     {
+                      "[AtomType]": "CharAtom",
                       "Character": "e",
                       "TextStyle": null,
                       "IsTextSymbol": false,
@@ -63,6 +71,7 @@
                       }
                     },
                     {
+                      "[AtomType]": "CharAtom",
                       "Character": "1",
                       "TextStyle": null,
                       "IsTextSymbol": false,
@@ -100,6 +109,7 @@
             }
           },
           "LeftDelimeter": {
+            "[AtomType]": "SymbolAtom",
             "IsDelimeter": true,
             "Name": "lbrack",
             "IsTextSymbol": false,
@@ -107,6 +117,7 @@
             "Source": null
           },
           "RightDelimeter": {
+            "[AtomType]": "SymbolAtom",
             "IsDelimeter": true,
             "Name": "rbrack",
             "IsTextSymbol": false,
@@ -125,9 +136,11 @@
       ],
       [
         {
+          "[AtomType]": "RowAtom",
           "PreviousAtom": null,
           "Elements": [
             {
+              "[AtomType]": "CharAtom",
               "Character": "l",
               "TextStyle": null,
               "IsTextSymbol": false,
@@ -141,6 +154,7 @@
               }
             },
             {
+              "[AtomType]": "CharAtom",
               "Character": "i",
               "TextStyle": null,
               "IsTextSymbol": false,
@@ -154,6 +168,7 @@
               }
             },
             {
+              "[AtomType]": "CharAtom",
               "Character": "n",
               "TextStyle": null,
               "IsTextSymbol": false,
@@ -167,6 +182,7 @@
               }
             },
             {
+              "[AtomType]": "CharAtom",
               "Character": "e",
               "TextStyle": null,
               "IsTextSymbol": false,
@@ -180,6 +196,7 @@
               }
             },
             {
+              "[AtomType]": "CharAtom",
               "Character": "2",
               "TextStyle": null,
               "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.oneNonAsciiSymbolText.approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.oneNonAsciiSymbolText.approved.txt
@@ -1,7 +1,9 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "ScriptsAtom",
     "BaseAtom": {
+      "[AtomType]": "CharAtom",
       "Character": "А",
       "TextStyle": "text",
       "IsTextSymbol": false,
@@ -15,6 +17,7 @@
       }
     },
     "SubscriptAtom": {
+      "[AtomType]": "CharAtom",
       "Character": "И",
       "TextStyle": "text",
       "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.overline.( (1)123).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.overline.( (1)123).approved.txt
@@ -1,10 +1,13 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "RowAtom",
     "PreviousAtom": null,
     "Elements": [
       {
+        "[AtomType]": "OverlinedAtom",
         "BaseAtom": {
+          "[AtomType]": "CharAtom",
           "Character": "1",
           "TextStyle": null,
           "IsTextSymbol": false,
@@ -27,6 +30,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "1",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -40,6 +44,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "2",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -53,6 +58,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "3",
         "TextStyle": null,
         "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.overline.( 1123).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.overline.( 1123).approved.txt
@@ -1,10 +1,13 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "RowAtom",
     "PreviousAtom": null,
     "Elements": [
       {
+        "[AtomType]": "OverlinedAtom",
         "BaseAtom": {
+          "[AtomType]": "CharAtom",
           "Character": "1",
           "TextStyle": null,
           "IsTextSymbol": false,
@@ -27,6 +30,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "1",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -40,6 +44,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "2",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -53,6 +58,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "3",
         "TextStyle": null,
         "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.overline.((1)123).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.overline.((1)123).approved.txt
@@ -1,10 +1,13 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "RowAtom",
     "PreviousAtom": null,
     "Elements": [
       {
+        "[AtomType]": "OverlinedAtom",
         "BaseAtom": {
+          "[AtomType]": "CharAtom",
           "Character": "1",
           "TextStyle": null,
           "IsTextSymbol": false,
@@ -27,6 +30,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "1",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -40,6 +44,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "2",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -53,6 +58,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "3",
         "TextStyle": null,
         "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.overline.(1123).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.overline.(1123).approved.txt
@@ -1,10 +1,13 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "RowAtom",
     "PreviousAtom": null,
     "Elements": [
       {
+        "[AtomType]": "OverlinedAtom",
         "BaseAtom": {
+          "[AtomType]": "CharAtom",
           "Character": "1",
           "TextStyle": null,
           "IsTextSymbol": false,
@@ -27,6 +30,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "1",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -40,6 +44,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "2",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -53,6 +58,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "3",
         "TextStyle": null,
         "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.piecewiseDefinedFunction.approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.piecewiseDefinedFunction.approved.txt
@@ -1,9 +1,11 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "RowAtom",
     "PreviousAtom": null,
     "Elements": [
       {
+        "[AtomType]": "CharAtom",
         "Character": "f",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -17,6 +19,7 @@
         }
       },
       {
+        "[AtomType]": "SymbolAtom",
         "IsDelimeter": true,
         "Name": "(",
         "IsTextSymbol": false,
@@ -30,6 +33,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "x",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -43,6 +47,7 @@
         }
       },
       {
+        "[AtomType]": "SymbolAtom",
         "IsDelimeter": true,
         "Name": ")",
         "IsTextSymbol": false,
@@ -56,6 +61,7 @@
         }
       },
       {
+        "[AtomType]": "SymbolAtom",
         "IsDelimeter": false,
         "Name": "equals",
         "IsTextSymbol": false,
@@ -69,13 +75,17 @@
         }
       },
       {
+        "[AtomType]": "FencedAtom",
         "BaseAtom": {
+          "[AtomType]": "MatrixAtom",
           "MatrixCells": [
             [
               {
+                "[AtomType]": "RowAtom",
                 "PreviousAtom": null,
                 "Elements": [
                   {
+                    "[AtomType]": "CharAtom",
                     "Character": "1",
                     "TextStyle": null,
                     "IsTextSymbol": false,
@@ -89,6 +99,7 @@
                     }
                   },
                   {
+                    "[AtomType]": "SymbolAtom",
                     "IsDelimeter": false,
                     "Name": "slash",
                     "IsTextSymbol": false,
@@ -102,6 +113,7 @@
                     }
                   },
                   {
+                    "[AtomType]": "CharAtom",
                     "Character": "3",
                     "TextStyle": null,
                     "IsTextSymbol": false,
@@ -125,9 +137,11 @@
                 }
               },
               {
+                "[AtomType]": "RowAtom",
                 "PreviousAtom": null,
                 "Elements": [
                   {
+                    "[AtomType]": "CharAtom",
                     "Character": "i",
                     "TextStyle": null,
                     "IsTextSymbol": false,
@@ -141,6 +155,7 @@
                     }
                   },
                   {
+                    "[AtomType]": "CharAtom",
                     "Character": "f",
                     "TextStyle": null,
                     "IsTextSymbol": false,
@@ -154,10 +169,12 @@
                     }
                   },
                   {
+                    "[AtomType]": "SpaceAtom",
                     "Type": "Ordinary",
                     "Source": null
                   },
                   {
+                    "[AtomType]": "CharAtom",
                     "Character": "0",
                     "TextStyle": null,
                     "IsTextSymbol": false,
@@ -171,6 +188,7 @@
                     }
                   },
                   {
+                    "[AtomType]": "SymbolAtom",
                     "IsDelimeter": false,
                     "Name": "le",
                     "IsTextSymbol": false,
@@ -184,6 +202,7 @@
                     }
                   },
                   {
+                    "[AtomType]": "CharAtom",
                     "Character": "x",
                     "TextStyle": null,
                     "IsTextSymbol": false,
@@ -197,6 +216,7 @@
                     }
                   },
                   {
+                    "[AtomType]": "SymbolAtom",
                     "IsDelimeter": false,
                     "Name": "le",
                     "IsTextSymbol": false,
@@ -210,6 +230,7 @@
                     }
                   },
                   {
+                    "[AtomType]": "CharAtom",
                     "Character": "1",
                     "TextStyle": null,
                     "IsTextSymbol": false,
@@ -223,6 +244,7 @@
                     }
                   },
                   {
+                    "[AtomType]": "SymbolAtom",
                     "IsDelimeter": false,
                     "Name": "semicolon",
                     "IsTextSymbol": false,
@@ -248,9 +270,11 @@
             ],
             [
               {
+                "[AtomType]": "RowAtom",
                 "PreviousAtom": null,
                 "Elements": [
                   {
+                    "[AtomType]": "CharAtom",
                     "Character": "2",
                     "TextStyle": null,
                     "IsTextSymbol": false,
@@ -264,6 +288,7 @@
                     }
                   },
                   {
+                    "[AtomType]": "SymbolAtom",
                     "IsDelimeter": false,
                     "Name": "slash",
                     "IsTextSymbol": false,
@@ -277,6 +302,7 @@
                     }
                   },
                   {
+                    "[AtomType]": "CharAtom",
                     "Character": "3",
                     "TextStyle": null,
                     "IsTextSymbol": false,
@@ -300,9 +326,11 @@
                 }
               },
               {
+                "[AtomType]": "RowAtom",
                 "PreviousAtom": null,
                 "Elements": [
                   {
+                    "[AtomType]": "CharAtom",
                     "Character": "i",
                     "TextStyle": null,
                     "IsTextSymbol": false,
@@ -316,6 +344,7 @@
                     }
                   },
                   {
+                    "[AtomType]": "CharAtom",
                     "Character": "f",
                     "TextStyle": null,
                     "IsTextSymbol": false,
@@ -329,10 +358,12 @@
                     }
                   },
                   {
+                    "[AtomType]": "SpaceAtom",
                     "Type": "Ordinary",
                     "Source": null
                   },
                   {
+                    "[AtomType]": "CharAtom",
                     "Character": "3",
                     "TextStyle": null,
                     "IsTextSymbol": false,
@@ -346,6 +377,7 @@
                     }
                   },
                   {
+                    "[AtomType]": "SymbolAtom",
                     "IsDelimeter": false,
                     "Name": "le",
                     "IsTextSymbol": false,
@@ -359,6 +391,7 @@
                     }
                   },
                   {
+                    "[AtomType]": "CharAtom",
                     "Character": "x",
                     "TextStyle": null,
                     "IsTextSymbol": false,
@@ -372,6 +405,7 @@
                     }
                   },
                   {
+                    "[AtomType]": "SymbolAtom",
                     "IsDelimeter": false,
                     "Name": "le",
                     "IsTextSymbol": false,
@@ -385,6 +419,7 @@
                     }
                   },
                   {
+                    "[AtomType]": "CharAtom",
                     "Character": "4",
                     "TextStyle": null,
                     "IsTextSymbol": false,
@@ -398,6 +433,7 @@
                     }
                   },
                   {
+                    "[AtomType]": "SymbolAtom",
                     "IsDelimeter": false,
                     "Name": "semicolon",
                     "IsTextSymbol": false,
@@ -423,6 +459,7 @@
             ],
             [
               {
+                "[AtomType]": "CharAtom",
                 "Character": "0",
                 "TextStyle": null,
                 "IsTextSymbol": false,
@@ -436,9 +473,11 @@
                 }
               },
               {
+                "[AtomType]": "RowAtom",
                 "PreviousAtom": null,
                 "Elements": [
                   {
+                    "[AtomType]": "CharAtom",
                     "Character": "e",
                     "TextStyle": null,
                     "IsTextSymbol": false,
@@ -452,6 +491,7 @@
                     }
                   },
                   {
+                    "[AtomType]": "CharAtom",
                     "Character": "l",
                     "TextStyle": null,
                     "IsTextSymbol": false,
@@ -465,6 +505,7 @@
                     }
                   },
                   {
+                    "[AtomType]": "CharAtom",
                     "Character": "s",
                     "TextStyle": null,
                     "IsTextSymbol": false,
@@ -478,6 +519,7 @@
                     }
                   },
                   {
+                    "[AtomType]": "CharAtom",
                     "Character": "e",
                     "TextStyle": null,
                     "IsTextSymbol": false,
@@ -491,6 +533,7 @@
                     }
                   },
                   {
+                    "[AtomType]": "CharAtom",
                     "Character": "w",
                     "TextStyle": null,
                     "IsTextSymbol": false,
@@ -504,6 +547,7 @@
                     }
                   },
                   {
+                    "[AtomType]": "CharAtom",
                     "Character": "h",
                     "TextStyle": null,
                     "IsTextSymbol": false,
@@ -517,6 +561,7 @@
                     }
                   },
                   {
+                    "[AtomType]": "CharAtom",
                     "Character": "e",
                     "TextStyle": null,
                     "IsTextSymbol": false,
@@ -530,6 +575,7 @@
                     }
                   },
                   {
+                    "[AtomType]": "CharAtom",
                     "Character": "r",
                     "TextStyle": null,
                     "IsTextSymbol": false,
@@ -543,6 +589,7 @@
                     }
                   },
                   {
+                    "[AtomType]": "CharAtom",
                     "Character": "e",
                     "TextStyle": null,
                     "IsTextSymbol": false,
@@ -556,6 +603,7 @@
                     }
                   },
                   {
+                    "[AtomType]": "SymbolAtom",
                     "IsDelimeter": false,
                     "Name": "normaldot",
                     "IsTextSymbol": false,
@@ -581,10 +629,12 @@
             ],
             [
               {
+                "[AtomType]": "NullAtom",
                 "Type": "Ordinary",
                 "Source": null
               },
               {
+                "[AtomType]": "NullAtom",
                 "Type": "Ordinary",
                 "Source": null
               }
@@ -603,6 +653,7 @@
           }
         },
         "LeftDelimeter": {
+          "[AtomType]": "SymbolAtom",
           "IsDelimeter": true,
           "Name": "lbrace",
           "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.scripts.(x ↑ (y) _ (z)).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.scripts.(x ↑ (y) _ (z)).approved.txt
@@ -1,7 +1,9 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "ScriptsAtom",
     "BaseAtom": {
+      "[AtomType]": "CharAtom",
       "Character": "x",
       "TextStyle": null,
       "IsTextSymbol": false,
@@ -15,6 +17,7 @@
       }
     },
     "SubscriptAtom": {
+      "[AtomType]": "CharAtom",
       "Character": "z",
       "TextStyle": null,
       "IsTextSymbol": false,
@@ -28,6 +31,7 @@
       }
     },
     "SuperscriptAtom": {
+      "[AtomType]": "CharAtom",
       "Character": "y",
       "TextStyle": null,
       "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.scripts.(x↑(y)_(z)).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.scripts.(x↑(y)_(z)).approved.txt
@@ -1,7 +1,9 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "ScriptsAtom",
     "BaseAtom": {
+      "[AtomType]": "CharAtom",
       "Character": "x",
       "TextStyle": null,
       "IsTextSymbol": false,
@@ -15,6 +17,7 @@
       }
     },
     "SubscriptAtom": {
+      "[AtomType]": "CharAtom",
       "Character": "z",
       "TextStyle": null,
       "IsTextSymbol": false,
@@ -28,6 +31,7 @@
       }
     },
     "SuperscriptAtom": {
+      "[AtomType]": "CharAtom",
       "Character": "y",
       "TextStyle": null,
       "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.scripts.(x↑(y)_z).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.scripts.(x↑(y)_z).approved.txt
@@ -1,7 +1,9 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "ScriptsAtom",
     "BaseAtom": {
+      "[AtomType]": "CharAtom",
       "Character": "x",
       "TextStyle": null,
       "IsTextSymbol": false,
@@ -15,6 +17,7 @@
       }
     },
     "SubscriptAtom": {
+      "[AtomType]": "CharAtom",
       "Character": "z",
       "TextStyle": null,
       "IsTextSymbol": false,
@@ -28,6 +31,7 @@
       }
     },
     "SuperscriptAtom": {
+      "[AtomType]": "CharAtom",
       "Character": "y",
       "TextStyle": null,
       "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.scripts.(x↑y_ z).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.scripts.(x↑y_ z).approved.txt
@@ -1,7 +1,9 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "ScriptsAtom",
     "BaseAtom": {
+      "[AtomType]": "CharAtom",
       "Character": "x",
       "TextStyle": null,
       "IsTextSymbol": false,
@@ -15,6 +17,7 @@
       }
     },
     "SubscriptAtom": {
+      "[AtomType]": "CharAtom",
       "Character": "z",
       "TextStyle": null,
       "IsTextSymbol": false,
@@ -28,6 +31,7 @@
       }
     },
     "SuperscriptAtom": {
+      "[AtomType]": "CharAtom",
       "Character": "y",
       "TextStyle": null,
       "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.scripts.(x↑y_(z)).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.scripts.(x↑y_(z)).approved.txt
@@ -1,7 +1,9 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "ScriptsAtom",
     "BaseAtom": {
+      "[AtomType]": "CharAtom",
       "Character": "x",
       "TextStyle": null,
       "IsTextSymbol": false,
@@ -15,6 +17,7 @@
       }
     },
     "SubscriptAtom": {
+      "[AtomType]": "CharAtom",
       "Character": "z",
       "TextStyle": null,
       "IsTextSymbol": false,
@@ -28,6 +31,7 @@
       }
     },
     "SuperscriptAtom": {
+      "[AtomType]": "CharAtom",
       "Character": "y",
       "TextStyle": null,
       "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.scripts.(x↑y_z).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.scripts.(x↑y_z).approved.txt
@@ -1,7 +1,9 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "ScriptsAtom",
     "BaseAtom": {
+      "[AtomType]": "CharAtom",
       "Character": "x",
       "TextStyle": null,
       "IsTextSymbol": false,
@@ -15,6 +17,7 @@
       }
     },
     "SubscriptAtom": {
+      "[AtomType]": "CharAtom",
       "Character": "z",
       "TextStyle": null,
       "IsTextSymbol": false,
@@ -28,6 +31,7 @@
       }
     },
     "SuperscriptAtom": {
+      "[AtomType]": "CharAtom",
       "Character": "y",
       "TextStyle": null,
       "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.simpleCases.approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.simpleCases.approved.txt
@@ -1,13 +1,17 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "FencedAtom",
     "BaseAtom": {
+      "[AtomType]": "MatrixAtom",
       "MatrixCells": [
         [
           {
+            "[AtomType]": "RowAtom",
             "PreviousAtom": null,
             "Elements": [
               {
+                "[AtomType]": "CharAtom",
                 "Character": "x",
                 "TextStyle": null,
                 "IsTextSymbol": false,
@@ -21,6 +25,7 @@
                 }
               },
               {
+                "[AtomType]": "SymbolAtom",
                 "IsDelimeter": false,
                 "Name": "comma",
                 "IsTextSymbol": false,
@@ -44,9 +49,11 @@
             }
           },
           {
+            "[AtomType]": "RowAtom",
             "PreviousAtom": null,
             "Elements": [
               {
+                "[AtomType]": "CharAtom",
                 "Character": "i",
                 "TextStyle": null,
                 "IsTextSymbol": false,
@@ -60,6 +67,7 @@
                 }
               },
               {
+                "[AtomType]": "CharAtom",
                 "Character": "f",
                 "TextStyle": null,
                 "IsTextSymbol": false,
@@ -73,6 +81,7 @@
                 }
               },
               {
+                "[AtomType]": "CharAtom",
                 "Character": "x",
                 "TextStyle": null,
                 "IsTextSymbol": false,
@@ -86,6 +95,7 @@
                 }
               },
               {
+                "[AtomType]": "SymbolAtom",
                 "IsDelimeter": false,
                 "Name": "gt",
                 "IsTextSymbol": false,
@@ -99,6 +109,7 @@
                 }
               },
               {
+                "[AtomType]": "CharAtom",
                 "Character": "0",
                 "TextStyle": null,
                 "IsTextSymbol": false,
@@ -112,6 +123,7 @@
                 }
               },
               {
+                "[AtomType]": "SymbolAtom",
                 "IsDelimeter": false,
                 "Name": "semicolon",
                 "IsTextSymbol": false,
@@ -137,9 +149,11 @@
         ],
         [
           {
+            "[AtomType]": "RowAtom",
             "PreviousAtom": null,
             "Elements": [
               {
+                "[AtomType]": "SymbolAtom",
                 "IsDelimeter": false,
                 "Name": "minus",
                 "IsTextSymbol": false,
@@ -153,6 +167,7 @@
                 }
               },
               {
+                "[AtomType]": "CharAtom",
                 "Character": "x",
                 "TextStyle": null,
                 "IsTextSymbol": false,
@@ -166,6 +181,7 @@
                 }
               },
               {
+                "[AtomType]": "SymbolAtom",
                 "IsDelimeter": false,
                 "Name": "comma",
                 "IsTextSymbol": false,
@@ -189,9 +205,11 @@
             }
           },
           {
+            "[AtomType]": "RowAtom",
             "PreviousAtom": null,
             "Elements": [
               {
+                "[AtomType]": "CharAtom",
                 "Character": "o",
                 "TextStyle": null,
                 "IsTextSymbol": false,
@@ -205,6 +223,7 @@
                 }
               },
               {
+                "[AtomType]": "CharAtom",
                 "Character": "t",
                 "TextStyle": null,
                 "IsTextSymbol": false,
@@ -218,6 +237,7 @@
                 }
               },
               {
+                "[AtomType]": "CharAtom",
                 "Character": "h",
                 "TextStyle": null,
                 "IsTextSymbol": false,
@@ -231,6 +251,7 @@
                 }
               },
               {
+                "[AtomType]": "CharAtom",
                 "Character": "e",
                 "TextStyle": null,
                 "IsTextSymbol": false,
@@ -244,6 +265,7 @@
                 }
               },
               {
+                "[AtomType]": "CharAtom",
                 "Character": "r",
                 "TextStyle": null,
                 "IsTextSymbol": false,
@@ -257,6 +279,7 @@
                 }
               },
               {
+                "[AtomType]": "CharAtom",
                 "Character": "w",
                 "TextStyle": null,
                 "IsTextSymbol": false,
@@ -270,6 +293,7 @@
                 }
               },
               {
+                "[AtomType]": "CharAtom",
                 "Character": "i",
                 "TextStyle": null,
                 "IsTextSymbol": false,
@@ -283,6 +307,7 @@
                 }
               },
               {
+                "[AtomType]": "CharAtom",
                 "Character": "s",
                 "TextStyle": null,
                 "IsTextSymbol": false,
@@ -296,6 +321,7 @@
                 }
               },
               {
+                "[AtomType]": "CharAtom",
                 "Character": "e",
                 "TextStyle": null,
                 "IsTextSymbol": false,
@@ -309,6 +335,7 @@
                 }
               },
               {
+                "[AtomType]": "SymbolAtom",
                 "IsDelimeter": false,
                 "Name": "normaldot",
                 "IsTextSymbol": false,
@@ -346,6 +373,7 @@
       }
     },
     "LeftDelimeter": {
+      "[AtomType]": "SymbolAtom",
       "IsDelimeter": true,
       "Name": "lbrace",
       "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.simpleMatrix.approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.simpleMatrix.approved.txt
@@ -1,9 +1,11 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "MatrixAtom",
     "MatrixCells": [
       [
         {
+          "[AtomType]": "CharAtom",
           "Character": "4",
           "TextStyle": null,
           "IsTextSymbol": false,
@@ -17,9 +19,11 @@
           }
         },
         {
+          "[AtomType]": "RowAtom",
           "PreviousAtom": null,
           "Elements": [
             {
+              "[AtomType]": "CharAtom",
               "Character": "7",
               "TextStyle": null,
               "IsTextSymbol": false,
@@ -33,6 +37,7 @@
               }
             },
             {
+              "[AtomType]": "CharAtom",
               "Character": "8",
               "TextStyle": null,
               "IsTextSymbol": false,
@@ -56,6 +61,7 @@
           }
         },
         {
+          "[AtomType]": "CharAtom",
           "Character": "3",
           "TextStyle": null,
           "IsTextSymbol": false,
@@ -71,6 +77,7 @@
       ],
       [
         {
+          "[AtomType]": "CharAtom",
           "Character": "5",
           "TextStyle": null,
           "IsTextSymbol": false,
@@ -84,6 +91,7 @@
           }
         },
         {
+          "[AtomType]": "CharAtom",
           "Character": "9",
           "TextStyle": null,
           "IsTextSymbol": false,
@@ -97,9 +105,11 @@
           }
         },
         {
+          "[AtomType]": "RowAtom",
           "PreviousAtom": null,
           "Elements": [
             {
+              "[AtomType]": "CharAtom",
               "Character": "8",
               "TextStyle": null,
               "IsTextSymbol": false,
@@ -113,6 +123,7 @@
               }
             },
             {
+              "[AtomType]": "CharAtom",
               "Character": "2",
               "TextStyle": null,
               "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.sin.approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.sin.approved.txt
@@ -1,13 +1,17 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "RowAtom",
     "PreviousAtom": null,
     "Elements": [
       {
+        "[AtomType]": "BigOperatorAtom",
         "BaseAtom": {
+          "[AtomType]": "RowAtom",
           "PreviousAtom": null,
           "Elements": [
             {
+              "[AtomType]": "CharAtom",
               "Character": "s",
               "TextStyle": "mathrm",
               "IsTextSymbol": false,
@@ -21,6 +25,7 @@
               }
             },
             {
+              "[AtomType]": "CharAtom",
               "Character": "i",
               "TextStyle": "mathrm",
               "IsTextSymbol": false,
@@ -34,6 +39,7 @@
               }
             },
             {
+              "[AtomType]": "CharAtom",
               "Character": "n",
               "TextStyle": "mathrm",
               "IsTextSymbol": false,
@@ -58,6 +64,7 @@
         },
         "LowerLimitAtom": null,
         "UpperLimitAtom": {
+          "[AtomType]": "CharAtom",
           "Character": "n",
           "TextStyle": null,
           "IsTextSymbol": false,
@@ -81,6 +88,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "x",
         "TextStyle": null,
         "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.spacesInText.approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.spacesInText.approved.txt
@@ -1,9 +1,11 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "RowAtom",
     "PreviousAtom": null,
     "Elements": [
       {
+        "[AtomType]": "CharAtom",
         "Character": "a",
         "TextStyle": "text",
         "IsTextSymbol": false,
@@ -17,6 +19,7 @@
         }
       },
       {
+        "[AtomType]": "SpaceAtom",
         "Type": "Ordinary",
         "Source": {
           "Start": 7,
@@ -27,6 +30,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "b",
         "TextStyle": "text",
         "IsTextSymbol": false,
@@ -40,6 +44,7 @@
         }
       },
       {
+        "[AtomType]": "SpaceAtom",
         "Type": "Ordinary",
         "Source": {
           "Start": 9,
@@ -50,6 +55,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "c",
         "TextStyle": "text",
         "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.sqrt.( (1)123).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.sqrt.( (1)123).approved.txt
@@ -1,10 +1,13 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "RowAtom",
     "PreviousAtom": null,
     "Elements": [
       {
+        "[AtomType]": "Radical",
         "BaseAtom": {
+          "[AtomType]": "CharAtom",
           "Character": "1",
           "TextStyle": null,
           "IsTextSymbol": false,
@@ -28,6 +31,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "1",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -41,6 +45,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "2",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -54,6 +59,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "3",
         "TextStyle": null,
         "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.sqrt.( 1123).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.sqrt.( 1123).approved.txt
@@ -1,10 +1,13 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "RowAtom",
     "PreviousAtom": null,
     "Elements": [
       {
+        "[AtomType]": "Radical",
         "BaseAtom": {
+          "[AtomType]": "CharAtom",
           "Character": "1",
           "TextStyle": null,
           "IsTextSymbol": false,
@@ -28,6 +31,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "1",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -41,6 +45,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "2",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -54,6 +59,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "3",
         "TextStyle": null,
         "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.sqrt.((1)123).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.sqrt.((1)123).approved.txt
@@ -1,10 +1,13 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "RowAtom",
     "PreviousAtom": null,
     "Elements": [
       {
+        "[AtomType]": "Radical",
         "BaseAtom": {
+          "[AtomType]": "CharAtom",
           "Character": "1",
           "TextStyle": null,
           "IsTextSymbol": false,
@@ -28,6 +31,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "1",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -41,6 +45,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "2",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -54,6 +59,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "3",
         "TextStyle": null,
         "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.sqrt.(1123).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.sqrt.(1123).approved.txt
@@ -1,10 +1,13 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "RowAtom",
     "PreviousAtom": null,
     "Elements": [
       {
+        "[AtomType]": "Radical",
         "BaseAtom": {
+          "[AtomType]": "CharAtom",
           "Character": "1",
           "TextStyle": null,
           "IsTextSymbol": false,
@@ -28,6 +31,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "1",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -41,6 +45,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "2",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -54,6 +59,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "3",
         "TextStyle": null,
         "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.sqrtWithOptArgument.( [ 2](1)123).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.sqrtWithOptArgument.( [ 2](1)123).approved.txt
@@ -1,10 +1,13 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "RowAtom",
     "PreviousAtom": null,
     "Elements": [
       {
+        "[AtomType]": "Radical",
         "BaseAtom": {
+          "[AtomType]": "CharAtom",
           "Character": "1",
           "TextStyle": null,
           "IsTextSymbol": false,
@@ -18,6 +21,7 @@
           }
         },
         "DegreeAtom": {
+          "[AtomType]": "CharAtom",
           "Character": "2",
           "TextStyle": null,
           "IsTextSymbol": false,
@@ -40,6 +44,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "1",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -53,6 +58,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "2",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -66,6 +72,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "3",
         "TextStyle": null,
         "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.sqrtWithOptArgument.( [2]1123).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.sqrtWithOptArgument.( [2]1123).approved.txt
@@ -1,10 +1,13 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "RowAtom",
     "PreviousAtom": null,
     "Elements": [
       {
+        "[AtomType]": "Radical",
         "BaseAtom": {
+          "[AtomType]": "CharAtom",
           "Character": "1",
           "TextStyle": null,
           "IsTextSymbol": false,
@@ -18,6 +21,7 @@
           }
         },
         "DegreeAtom": {
+          "[AtomType]": "CharAtom",
           "Character": "2",
           "TextStyle": null,
           "IsTextSymbol": false,
@@ -40,6 +44,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "1",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -53,6 +58,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "2",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -66,6 +72,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "3",
         "TextStyle": null,
         "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.sqrtWithOptArgument.([ 2 ] (1)123).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.sqrtWithOptArgument.([ 2 ] (1)123).approved.txt
@@ -1,10 +1,13 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "RowAtom",
     "PreviousAtom": null,
     "Elements": [
       {
+        "[AtomType]": "Radical",
         "BaseAtom": {
+          "[AtomType]": "CharAtom",
           "Character": "1",
           "TextStyle": null,
           "IsTextSymbol": false,
@@ -18,6 +21,7 @@
           }
         },
         "DegreeAtom": {
+          "[AtomType]": "CharAtom",
           "Character": "2",
           "TextStyle": null,
           "IsTextSymbol": false,
@@ -40,6 +44,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "1",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -53,6 +58,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "2",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -66,6 +72,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "3",
         "TextStyle": null,
         "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.sqrtWithOptArgument.([2 ] 1123).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.sqrtWithOptArgument.([2 ] 1123).approved.txt
@@ -1,10 +1,13 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "RowAtom",
     "PreviousAtom": null,
     "Elements": [
       {
+        "[AtomType]": "Radical",
         "BaseAtom": {
+          "[AtomType]": "CharAtom",
           "Character": "1",
           "TextStyle": null,
           "IsTextSymbol": false,
@@ -18,6 +21,7 @@
           }
         },
         "DegreeAtom": {
+          "[AtomType]": "CharAtom",
           "Character": "2",
           "TextStyle": null,
           "IsTextSymbol": false,
@@ -40,6 +44,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "1",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -53,6 +58,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "2",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -66,6 +72,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "3",
         "TextStyle": null,
         "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.textArgumentParsing.( (1)123).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.textArgumentParsing.( (1)123).approved.txt
@@ -1,9 +1,11 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "RowAtom",
     "PreviousAtom": null,
     "Elements": [
       {
+        "[AtomType]": "CharAtom",
         "Character": "1",
         "TextStyle": "text",
         "IsTextSymbol": false,
@@ -17,6 +19,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "1",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -30,6 +33,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "2",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -43,6 +47,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "3",
         "TextStyle": null,
         "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.textArgumentParsing.( 1123).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.textArgumentParsing.( 1123).approved.txt
@@ -1,9 +1,11 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "RowAtom",
     "PreviousAtom": null,
     "Elements": [
       {
+        "[AtomType]": "CharAtom",
         "Character": "1",
         "TextStyle": "text",
         "IsTextSymbol": false,
@@ -17,6 +19,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "1",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -30,6 +33,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "2",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -43,6 +47,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "3",
         "TextStyle": null,
         "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.textCommand.approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.textCommand.approved.txt
@@ -1,9 +1,11 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "RowAtom",
     "PreviousAtom": null,
     "Elements": [
       {
+        "[AtomType]": "CharAtom",
         "Character": "t",
         "TextStyle": "text",
         "IsTextSymbol": false,
@@ -17,6 +19,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "e",
         "TextStyle": "text",
         "IsTextSymbol": false,
@@ -30,6 +33,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "s",
         "TextStyle": "text",
         "IsTextSymbol": false,
@@ -43,6 +47,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "t",
         "TextStyle": "text",
         "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.textWithExpression.approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.textWithExpression.approved.txt
@@ -1,9 +1,11 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "RowAtom",
     "PreviousAtom": null,
     "Elements": [
       {
+        "[AtomType]": "CharAtom",
         "Character": "2",
         "TextStyle": "text",
         "IsTextSymbol": false,
@@ -17,6 +19,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "+",
         "TextStyle": "text",
         "IsTextSymbol": false,
@@ -30,6 +33,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "2",
         "TextStyle": "text",
         "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.underline.( (1)123).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.underline.( (1)123).approved.txt
@@ -1,10 +1,13 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "RowAtom",
     "PreviousAtom": null,
     "Elements": [
       {
+        "[AtomType]": "UnderlinedAtom",
         "BaseAtom": {
+          "[AtomType]": "CharAtom",
           "Character": "1",
           "TextStyle": null,
           "IsTextSymbol": false,
@@ -27,6 +30,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "1",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -40,6 +44,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "2",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -53,6 +58,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "3",
         "TextStyle": null,
         "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.underline.( 1123).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.underline.( 1123).approved.txt
@@ -1,10 +1,13 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "RowAtom",
     "PreviousAtom": null,
     "Elements": [
       {
+        "[AtomType]": "UnderlinedAtom",
         "BaseAtom": {
+          "[AtomType]": "CharAtom",
           "Character": "1",
           "TextStyle": null,
           "IsTextSymbol": false,
@@ -27,6 +30,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "1",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -40,6 +44,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "2",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -53,6 +58,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "3",
         "TextStyle": null,
         "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.underline.((1)123).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.underline.((1)123).approved.txt
@@ -1,10 +1,13 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "RowAtom",
     "PreviousAtom": null,
     "Elements": [
       {
+        "[AtomType]": "UnderlinedAtom",
         "BaseAtom": {
+          "[AtomType]": "CharAtom",
           "Character": "1",
           "TextStyle": null,
           "IsTextSymbol": false,
@@ -27,6 +30,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "1",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -40,6 +44,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "2",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -53,6 +58,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "3",
         "TextStyle": null,
         "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.underline.(1123).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.underline.(1123).approved.txt
@@ -1,10 +1,13 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "RowAtom",
     "PreviousAtom": null,
     "Elements": [
       {
+        "[AtomType]": "UnderlinedAtom",
         "BaseAtom": {
+          "[AtomType]": "CharAtom",
           "Character": "1",
           "TextStyle": null,
           "IsTextSymbol": false,
@@ -27,6 +30,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "1",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -40,6 +44,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "2",
         "TextStyle": null,
         "IsTextSymbol": false,
@@ -53,6 +58,7 @@
         }
       },
       {
+        "[AtomType]": "CharAtom",
         "Character": "3",
         "TextStyle": null,
         "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.underscoreText.approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.underscoreText.approved.txt
@@ -1,6 +1,7 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "CharAtom",
     "Character": "_",
     "TextStyle": "text",
     "IsTextSymbol": false,

--- a/src/WpfMath.Tests/TestResults/ParserTests.unmatchedDelimiters.approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.unmatchedDelimiters.approved.txt
@@ -1,7 +1,9 @@
 {
   "TextStyle": null,
   "RootAtom": {
+    "[AtomType]": "FencedAtom",
     "BaseAtom": {
+      "[AtomType]": "CharAtom",
       "Character": "a",
       "TextStyle": null,
       "IsTextSymbol": false,
@@ -15,6 +17,7 @@
       }
     },
     "LeftDelimeter": {
+      "[AtomType]": "SymbolAtom",
       "IsDelimeter": true,
       "Name": ")",
       "IsTextSymbol": false,
@@ -28,6 +31,7 @@
       }
     },
     "RightDelimeter": {
+      "[AtomType]": "SymbolAtom",
       "IsDelimeter": true,
       "Name": "vert",
       "IsTextSymbol": false,


### PR DESCRIPTION
This adds an `[AtomType]` property to all types derived of `Atom`. Don't know any F#, though, so code is probably abysmal.

Fixes #188.