### PR TITLE
Fix predefined formula context sharing

### DIFF
--- a/src/WpfMath.Tests/ParserTests.fs
+++ b/src/WpfMath.Tests/ParserTests.fs
@@ -87,6 +87,10 @@ let lim() =
 [<Fact>]
 let limInCurlyBraces() =
     verifyParseResult @"{\lim} x"
+    
+[<Fact>]
+let limsup() =
+    verifyParseResult @"\limsup"
 
 [<Fact>]
 let sin() =

--- a/src/WpfMath.Tests/TestResults/ParserTests.limsup.approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.limsup.approved.txt
@@ -1,0 +1,127 @@
+{
+  "TextStyle": null,
+  "RootAtom": {
+    "[AtomType]": "BigOperatorAtom",
+    "BaseAtom": {
+      "[AtomType]": "RowAtom",
+      "PreviousAtom": null,
+      "Elements": [
+        {
+          "[AtomType]": "CharAtom",
+          "Character": "l",
+          "TextStyle": "mathrm",
+          "IsTextSymbol": false,
+          "Type": "Ordinary",
+          "Source": {
+            "Start": 8,
+            "End": 9,
+            "Length": 1,
+            "Source": "\\mathrm{lim\\,sup}",
+            "SourceName": "Predefined formula fragment"
+          }
+        },
+        {
+          "[AtomType]": "CharAtom",
+          "Character": "i",
+          "TextStyle": "mathrm",
+          "IsTextSymbol": false,
+          "Type": "Ordinary",
+          "Source": {
+            "Start": 9,
+            "End": 10,
+            "Length": 1,
+            "Source": "\\mathrm{lim\\,sup}",
+            "SourceName": "Predefined formula fragment"
+          }
+        },
+        {
+          "[AtomType]": "CharAtom",
+          "Character": "m",
+          "TextStyle": "mathrm",
+          "IsTextSymbol": false,
+          "Type": "Ordinary",
+          "Source": {
+            "Start": 10,
+            "End": 11,
+            "Length": 1,
+            "Source": "\\mathrm{lim\\,sup}",
+            "SourceName": "Predefined formula fragment"
+          }
+        },
+        {
+          "[AtomType]": "SpaceAtom",
+          "Type": "Ordinary",
+          "Source": null
+        },
+        {
+          "[AtomType]": "CharAtom",
+          "Character": "s",
+          "TextStyle": "mathrm",
+          "IsTextSymbol": false,
+          "Type": "Ordinary",
+          "Source": {
+            "Start": 13,
+            "End": 14,
+            "Length": 1,
+            "Source": "\\mathrm{lim\\,sup}",
+            "SourceName": "Predefined formula fragment"
+          }
+        },
+        {
+          "[AtomType]": "CharAtom",
+          "Character": "u",
+          "TextStyle": "mathrm",
+          "IsTextSymbol": false,
+          "Type": "Ordinary",
+          "Source": {
+            "Start": 14,
+            "End": 15,
+            "Length": 1,
+            "Source": "\\mathrm{lim\\,sup}",
+            "SourceName": "Predefined formula fragment"
+          }
+        },
+        {
+          "[AtomType]": "CharAtom",
+          "Character": "p",
+          "TextStyle": "mathrm",
+          "IsTextSymbol": false,
+          "Type": "Ordinary",
+          "Source": {
+            "Start": 15,
+            "End": 16,
+            "Length": 1,
+            "Source": "\\mathrm{lim\\,sup}",
+            "SourceName": "Predefined formula fragment"
+          }
+        }
+      ],
+      "Type": "Ordinary",
+      "Source": {
+        "Start": 8,
+        "End": 16,
+        "Length": 8,
+        "Source": "\\mathrm{lim\\,sup}",
+        "SourceName": "Predefined formula fragment"
+      }
+    },
+    "LowerLimitAtom": null,
+    "UpperLimitAtom": null,
+    "UseVerticalLimits": true,
+    "Type": "BigOperator",
+    "Source": {
+      "Start": 8,
+      "End": 16,
+      "Length": 8,
+      "Source": "\\mathrm{lim\\,sup}",
+      "SourceName": "Predefined formula fragment"
+    }
+  },
+  "Source": {
+    "Start": 0,
+    "End": 7,
+    "Length": 7,
+    "Source": "\\limsup",
+    "SourceName": "User input"
+  }
+}

--- a/src/WpfMath/Parsers/PredefinedFormulae/PredefinedFormulaContext.cs
+++ b/src/WpfMath/Parsers/PredefinedFormulae/PredefinedFormulaContext.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+
+namespace WpfMath.Parsers.PredefinedFormulae
+{
+    /// <summary>
+    /// This is a context for parsing a predefined formula. <c>PredefinedTexFormulas.xml</c> allows the users to
+    /// introduce their own named formulae via <example>&lt;CreateFormula name="f"&gt;</example>, and then call methods
+    /// on them.
+    /// <para/>
+    /// This context is the storage of these named formula values.
+    /// </summary>
+    internal class PredefinedFormulaContext
+    {
+        private readonly Dictionary<string, TexFormula> _formulae = new Dictionary<string, TexFormula>();
+        public void AddFormula(string name, TexFormula formula) => _formulae.Add(name, formula);
+        public TexFormula this[string name] => _formulae[name];
+    }
+}

--- a/src/WpfMath/TexPredefinedFormulaParser.cs
+++ b/src/WpfMath/TexPredefinedFormulaParser.cs
@@ -141,7 +141,13 @@ namespace WpfMath
                 var argValues = GetArgumentValues(args);
 
                 var helper = new TexFormulaHelper(formula, source);
-                typeof(TexFormulaHelper).GetMethod(methodName, argTypes)!.Invoke(helper, argValues);
+                var methodInvocation = typeof(TexFormulaHelper).GetMethod(methodName, argTypes)!;
+
+                // Since PredefinedTexFormulas can be used again when MethodInvocation is executed,
+                // we need to protect ourselves from re-adding the key-value to the SharedCacheFormulas
+                this.SharedCacheFormulas.Remove(objectName);
+                methodInvocation.Invoke(helper, argValues);
+                this.SharedCacheFormulas[objectName] = formula;
             }
         }
 


### PR DESCRIPTION
Closes #244, obsoletes #245 (and incorporates a test from it, for that matter).

This is a terminal fix for all the `TexPredefinedFormulas.xml` we were having earlier. I think I was already explaining this solution somewhere in my PR comments, but I've lost that comment since then. So, I had to reinvent this solution again!