### PR TITLE
Support setting foreground and background via WPF control properties

### DIFF
--- a/src/WpfMath/Controls/FormulaControl.xaml.cs
+++ b/src/WpfMath/Controls/FormulaControl.xaml.cs
@@ -65,10 +65,10 @@ namespace WpfMath.Controls
             set { SetValue(SelectionLengthProperty, value); }
         }
 
-        public Brush SelectionBrush
+        public Brush? SelectionBrush
         {
-            get { return (Brush)GetValue(SelectionBrushProperty); }
-            set { SetValue(SelectionBrushProperty, value); }
+            get => (Brush)GetValue(SelectionBrushProperty);
+            set => SetValue(SelectionBrushProperty, value);
         }
 
         public static readonly DependencyProperty FormulaProperty = DependencyProperty.Register(
@@ -107,6 +107,17 @@ namespace WpfMath.Controls
             nameof(SelectionBrush), typeof(Brush), typeof(FormulaControl),
             new PropertyMetadata(null, OnRenderSettingsChanged));
 
+        static FormulaControl()
+        {
+            // Call OnRenderSettingsChanged on Foreground property change.
+            ForegroundProperty.OverrideMetadata(
+                typeof(FormulaControl),
+                new FrameworkPropertyMetadata(
+                    SystemColors.ControlTextBrush,
+                    FrameworkPropertyMetadataOptions.Inherits,
+                    OnRenderSettingsChanged));
+        }
+
         public FormulaControl()
         {
             InitializeComponent();
@@ -123,7 +134,9 @@ namespace WpfMath.Controls
 
             // Render formula to visual.
             var visual = new DrawingVisual();
-            var renderer = texFormula.GetRenderer(TexStyle.Display, Scale, SystemTextFontName);
+
+            // Pass transparent background, since the control background will be effectively used anyway.
+            var renderer = texFormula.GetRenderer(TexStyle.Display, Scale, SystemTextFontName, Brushes.Transparent, Foreground);
             var formulaSource = texFormula.Source;
             if (formulaSource != null)
             {

--- a/src/WpfMath/TexEnvironment.cs
+++ b/src/WpfMath/TexEnvironment.cs
@@ -8,12 +8,12 @@ namespace WpfMath
         // ID of font that was last used.
         private int lastFontId = TexFontUtilities.NoFontId;
 
-        public TexEnvironment(TexStyle style, ITeXFont mathFont, ITeXFont textFont)
-            : this(style, mathFont, textFont, null, null)
-        {
-        }
-
-        private TexEnvironment(TexStyle style, ITeXFont mathFont, ITeXFont textFont, Brush? background, Brush? foreground)
+        public TexEnvironment(
+            TexStyle style,
+            ITeXFont mathFont,
+            ITeXFont textFont,
+            Brush? background = null,
+            Brush? foreground = null)
         {
             if (style == TexStyle.Display || style == TexStyle.Text ||
                 style == TexStyle.Script || style == TexStyle.ScriptScript)

--- a/src/WpfMath/TexFormula.cs
+++ b/src/WpfMath/TexFormula.cs
@@ -24,11 +24,15 @@ namespace WpfMath
 
         public SourceSpan? Source { get; set; }
 
-        public TexRenderer GetRenderer(TexStyle style, double scale, string systemTextFontName)
+        public TexRenderer GetRenderer(TexStyle style,
+            double scale,
+            string? systemTextFontName,
+            Brush? background = null,
+            Brush? foreground = null)
         {
             var mathFont = new DefaultTexFont(scale);
             var textFont = systemTextFontName == null ? (ITeXFont)mathFont : GetSystemFont(systemTextFontName, scale);
-            var environment = new TexEnvironment(style, mathFont, textFont);
+            var environment = new TexEnvironment(style, mathFont, textFont, background, foreground);
             return new TexRenderer(CreateBox(environment), scale);
         }
 


### PR DESCRIPTION
Closes #99. Obsoletes #162.

I've decided not to keep the binary compatibility with `TexFormula.GetRenderer` signature, since we're still technically in `0.*` version range.