### PR TITLE
.gitattributes: text=auto

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-* text eol=lf
+* text=auto eol=lf


### PR DESCRIPTION
Without this change, files get weirdly mangled on checking them out, `git rebase` and whatnot.

Initially, I got this version of `.gitattributes` from [this comment](https://github.com/actions/checkout/issues/135#issuecomment-613361104) on GitHub `checkout` Action repository.

Why have I even introduced this? Because I've decided we want to keep the line endings as `\n` (otherwise, they themselves get occasionally messed up by myself and other contributors). And then I found that GitHub Actions check out the repository with `autocrlf=true` on Windows. To avoid that, I wanted to do an equivalent of `core.autocrlf=input`, and took the advice from the aforementioned comment.

I was wrong, and I hope the problem gets fixed by this.