### PR TITLE
Read changelog uses ForNeVeR/ChangelogAutomation.action@v1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,28 +9,33 @@ on:
   schedule:
     - cron: '0 0 * * 6'
 
+  workflow_dispatch:
+
 jobs:
   main:
     runs-on: windows-2019
+
     env:
       DOTNET_NOLOGO: 1
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
       NUGET_PACKAGES: ${{ github.workspace }}/.github/nuget-packages
+
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Verify encoding
         shell: pwsh
         run: ./scripts/verify-encoding.ps1
 
       - name: NuGet cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ env.NUGET_PACKAGES }}
           key: ${{ runner.os }}.nuget.${{ hashFiles('**/*.csproj') }}
+
       - name: Set up .NET SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: |
             3.1.x
@@ -39,7 +44,9 @@ jobs:
 
       - name: Build
         run: dotnet build
+
       - name: Pack
         run: dotnet pack
+
       - name: Test
         run: dotnet test

--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -4,6 +4,8 @@ on:
     tags:
       - 'v*'
 
+  workflow_dispatch:
+
 jobs:
   nuget-push:
     runs-on: windows-2019
@@ -18,25 +20,27 @@ jobs:
         run: Write-Output "::set-output name=version::$($env:GITHUB_REF -replace '^refs/tags/v', '')"
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: NuGet cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ env.NUGET_PACKAGES }}
           key: release.nuget.${{ hashFiles('**/*.csproj') }}
+
       - name: Set up .NET SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '7.0.x'
 
       - name: Prepare a NuGet package
         run: dotnet pack --configuration Release -p:Version=${{ steps.version.outputs.version }}
+
       - name: Read changelog
         id: changelog
-        uses: mindsers/changelog-reader-action@v2
+        uses: ForNeVeR/ChangelogAutomation.action@v1
         with:
-          version: ${{ steps.version.outputs.version }}
+          output: ./release-notes.md
 
       - name: Create release
         id: release
@@ -46,7 +50,8 @@ jobs:
         with:
           tag_name: ${{ github.ref }}
           release_name: WPF-Math v${{ steps.version.outputs.version }}
-          body: ${{ steps.changelog.outputs.changes }}
+          body_path: ./release-notes.md
+
       - name: Upload .nupkg file
         uses: actions/upload-release-asset@v1
         env:
@@ -56,6 +61,7 @@ jobs:
           asset_name: WPF-Math.${{ steps.version.outputs.version }}.nupkg
           asset_path: ./src/WpfMath/bin/Release/WpfMath.${{ steps.version.outputs.version }}.nupkg
           asset_content_type: application/zip
+
       - name: Upload .snupkg file
         uses: actions/upload-release-asset@v1
         env:


### PR DESCRIPTION
Fixes partially: https://github.com/ForNeVeR/wpf-math/issues/298

What's new:

- Step `Read changelog` uses `ForNeVeR/ChangelogAutomation.action@v1`
- Versions bump for `checkout`, `cache`, `setup-dotnet`
- Added `workflow_dispatch` trigger

PS, I am not able to test nuget push due to security precautions of Github, however, output of read change log file is there: https://github.com/kolosovpetro/wpf-math/actions/runs/4018962182/jobs/6905216105#step:8:11