### PR TITLE
Add bmatrix/Bmatrix/vmatrix/Vmatrix matrix delimiter environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning v2.0.0](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased] (3.0.0)
+### Added
+- New matrix delimiter environments `bmatrix` (`[ ]`), `Bmatrix` (`{ }`), `vmatrix` (`| |`), and `Vmatrix` (`‖ ‖`), each usable both as a command (e.g. `\bmatrix{…}`) and as an environment (e.g. `\begin{bmatrix}…\end{bmatrix}`).
+
 ### Removed
 - **(Breaking change!)** Support for .NET 6 and 7. The new list of supported frameworks:
   - for **WPF-Math**: **.NET Framework 4.6.2** or later, **.NET 8** or later;
@@ -12,6 +15,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 - The exception classes are now `sealed` (should not break anything, since there never was any sense in extending them in the user code).
 - Avalonia: `AvaloniaMathFontProvider::Instance` is now read-only.
+
+### Fixed
+- `pmatrix` now renders with parentheses `( )` instead of square brackets `[ ]`, matching LaTeX (the square-bracket variant is `bmatrix`).
 
 ## [2.1.0] - 2023-07-15
 ### Changed

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -6,7 +6,7 @@ XAML-Math supports _environments_: ability to introduce certain context for the 
 
 List of currently supported environment names:
 
-- `pmatrix`: works the same as the [corresponding matrix command][docs.matrices].
+- `pmatrix`, `bmatrix`, `Bmatrix`, `vmatrix`, `Vmatrix`: each works the same as the [corresponding matrix command][docs.matrices], differing only in the delimiters that surround the matrix.
 
   Examples:
   ```tex

--- a/docs/matrices.md
+++ b/docs/matrices.md
@@ -16,10 +16,14 @@ For example, the following command creates a matrix with 2 rows and 3 columns:
 \matrix{1 & 2 & 3 \\ 4 & 5 & 6}
 ```
 
-There're two matrix types supported:
+The following matrix types are supported (each named after its delimiters, following LaTeX/amsmath):
 
-- `\matrix`: a matrix without brackets
-- `\pmatrix`: a matrix within square brackets
+- `\matrix`: a matrix without delimiters
+- `\pmatrix`: a matrix within parentheses `( )`
+- `\bmatrix`: a matrix within square brackets `[ ]`
+- `\Bmatrix`: a matrix within curly braces `{ }`
+- `\vmatrix`: a matrix within single vertical bars `| |`
+- `\Vmatrix`: a matrix within double vertical bars `‖ ‖`
 
 There's also a matrix-like construct:
 

--- a/src/WpfMath.Tests/BoxTests.fs
+++ b/src/WpfMath.Tests/BoxTests.fs
@@ -112,6 +112,22 @@ let wideItemInMatrixBox() =
     verifyBox @"x = \pmatrix{0 & -r & 0 \\ 0 & 0 & -r sin^2(\theta)}"
 
 [<Fact>]
+let bMatrixBox() =
+    verifyBox @"\bmatrix{2 & 2 \\ 2 & 2}"
+
+[<Fact>]
+let bbMatrixBox() =
+    verifyBox @"\Bmatrix{2 & 2 \\ 2 & 2}"
+
+[<Fact>]
+let vMatrixBox() =
+    verifyBox @"\vmatrix{2 & 2 \\ 2 & 2}"
+
+[<Fact>]
+let vvMatrixBox() =
+    verifyBox @"\Vmatrix{2 & 2 \\ 2 & 2}"
+
+[<Fact>]
 let emptyCellMatrix() =
     verifyBox @"\matrix{A & B \\ A & B \\ & B}"
 

--- a/src/WpfMath.Tests/EnvironmentTests.fs
+++ b/src/WpfMath.Tests/EnvironmentTests.fs
@@ -19,6 +19,22 @@ let pMatrixEnvironment(): unit =
     verifyParseResult @"\begin{pmatrix}{line 1}\\line 2\end{pmatrix}"
 
 [<Fact>]
+let bMatrixEnvironment(): unit =
+    verifyParseResult @"\begin{bmatrix}a & b \\ c & d\end{bmatrix}"
+
+[<Fact>]
+let bbMatrixEnvironment(): unit =
+    verifyParseResult @"\begin{Bmatrix}a & b \\ c & d\end{Bmatrix}"
+
+[<Fact>]
+let vMatrixEnvironment(): unit =
+    verifyParseResult @"\begin{vmatrix}a & b \\ c & d\end{vmatrix}"
+
+[<Fact>]
+let vvMatrixEnvironment(): unit =
+    verifyParseResult @"\begin{Vmatrix}a & b \\ c & d\end{Vmatrix}"
+
+[<Fact>]
 let nestedEnvironment(): unit =
     verifyParseResult @"\begin{pmatrix}line 1\\\begin{pmatrix}line x\end{pmatrix}\end{pmatrix}"
 

--- a/src/WpfMath.Tests/TestResults/BoxTests.bMatrixBox.approved.txt
+++ b/src/WpfMath.Tests/TestResults/BoxTests.bMatrixBox.approved.txt
@@ -4,14 +4,14 @@
     {
       "Background": null,
       "Character": {
-        "Character": "³",
+        "Character": "h",
         "Font": "pack://application:,,,/WpfMath;component/Fonts/cmex10.ttf",
         "FontId": 2,
         "Metrics": {
           "Depth": 1.760019,
           "Height": 0.039999,
           "Italic": 0.0,
-          "Width": 0.597224
+          "Width": 0.472224
         },
         "Size": 1.0
       },
@@ -23,8 +23,8 @@
       "Shift": -1.11001,
       "Source": null,
       "TotalHeight": 1.800018,
-      "TotalWidth": 0.597224,
-      "Width": 0.597224
+      "TotalWidth": 0.472224,
+      "Width": 0.472224
     },
     {
       "Background": null,
@@ -99,7 +99,7 @@
                   "Source": {
                     "End": 10,
                     "Length": 1,
-                    "Source": "\\pmatrix{2 & 2 \\\\ 2 & 2}",
+                    "Source": "\\bmatrix{2 & 2 \\\\ 2 & 2}",
                     "SourceName": "User input",
                     "Start": 9
                   },
@@ -196,7 +196,7 @@
                   "Source": {
                     "End": 14,
                     "Length": 1,
-                    "Source": "\\pmatrix{2 & 2 \\\\ 2 & 2}",
+                    "Source": "\\bmatrix{2 & 2 \\\\ 2 & 2}",
                     "SourceName": "User input",
                     "Start": 13
                   },
@@ -307,7 +307,7 @@
                   "Source": {
                     "End": 19,
                     "Length": 1,
-                    "Source": "\\pmatrix{2 & 2 \\\\ 2 & 2}",
+                    "Source": "\\bmatrix{2 & 2 \\\\ 2 & 2}",
                     "SourceName": "User input",
                     "Start": 18
                   },
@@ -404,7 +404,7 @@
                   "Source": {
                     "End": 23,
                     "Length": 1,
-                    "Source": "\\pmatrix{2 & 2 \\\\ 2 & 2}",
+                    "Source": "\\bmatrix{2 & 2 \\\\ 2 & 2}",
                     "SourceName": "User input",
                     "Start": 22
                   },
@@ -469,7 +469,7 @@
       "Source": {
         "End": 24,
         "Length": 23,
-        "Source": "\\pmatrix{2 & 2 \\\\ 2 & 2}",
+        "Source": "\\bmatrix{2 & 2 \\\\ 2 & 2}",
         "SourceName": "User input",
         "Start": 1
       },
@@ -495,14 +495,14 @@
     {
       "Background": null,
       "Character": {
-        "Character": "´",
+        "Character": "i",
         "Font": "pack://application:,,,/WpfMath;component/Fonts/cmex10.ttf",
         "FontId": 2,
         "Metrics": {
           "Depth": 1.760019,
           "Height": 0.039999,
           "Italic": 0.0,
-          "Width": 0.597224
+          "Width": 0.472224
         },
         "Size": 1.0
       },
@@ -514,8 +514,8 @@
       "Shift": -1.11001,
       "Source": null,
       "TotalHeight": 1.800018,
-      "TotalWidth": 0.597224,
-      "Width": 0.597224
+      "TotalWidth": 0.472224,
+      "Width": 0.472224
     }
   ],
   "Depth": 0.744444,
@@ -526,11 +526,11 @@
   "Source": {
     "End": 24,
     "Length": 23,
-    "Source": "\\pmatrix{2 & 2 \\\\ 2 & 2}",
+    "Source": "\\bmatrix{2 & 2 \\\\ 2 & 2}",
     "SourceName": "User input",
     "Start": 1
   },
   "TotalHeight": 1.988888,
-  "TotalWidth": 2.894452,
-  "Width": 2.894452
+  "TotalWidth": 2.644452,
+  "Width": 2.644452
 }

--- a/src/WpfMath.Tests/TestResults/BoxTests.bbMatrixBox.approved.txt
+++ b/src/WpfMath.Tests/TestResults/BoxTests.bbMatrixBox.approved.txt
@@ -4,14 +4,14 @@
     {
       "Background": null,
       "Character": {
-        "Character": "³",
+        "Character": "n",
         "Font": "pack://application:,,,/WpfMath;component/Fonts/cmex10.ttf",
         "FontId": 2,
         "Metrics": {
           "Depth": 1.760019,
           "Height": 0.039999,
           "Italic": 0.0,
-          "Width": 0.597224
+          "Width": 0.666669
         },
         "Size": 1.0
       },
@@ -23,8 +23,8 @@
       "Shift": -1.11001,
       "Source": null,
       "TotalHeight": 1.800018,
-      "TotalWidth": 0.597224,
-      "Width": 0.597224
+      "TotalWidth": 0.666669,
+      "Width": 0.666669
     },
     {
       "Background": null,
@@ -99,7 +99,7 @@
                   "Source": {
                     "End": 10,
                     "Length": 1,
-                    "Source": "\\pmatrix{2 & 2 \\\\ 2 & 2}",
+                    "Source": "\\Bmatrix{2 & 2 \\\\ 2 & 2}",
                     "SourceName": "User input",
                     "Start": 9
                   },
@@ -196,7 +196,7 @@
                   "Source": {
                     "End": 14,
                     "Length": 1,
-                    "Source": "\\pmatrix{2 & 2 \\\\ 2 & 2}",
+                    "Source": "\\Bmatrix{2 & 2 \\\\ 2 & 2}",
                     "SourceName": "User input",
                     "Start": 13
                   },
@@ -307,7 +307,7 @@
                   "Source": {
                     "End": 19,
                     "Length": 1,
-                    "Source": "\\pmatrix{2 & 2 \\\\ 2 & 2}",
+                    "Source": "\\Bmatrix{2 & 2 \\\\ 2 & 2}",
                     "SourceName": "User input",
                     "Start": 18
                   },
@@ -404,7 +404,7 @@
                   "Source": {
                     "End": 23,
                     "Length": 1,
-                    "Source": "\\pmatrix{2 & 2 \\\\ 2 & 2}",
+                    "Source": "\\Bmatrix{2 & 2 \\\\ 2 & 2}",
                     "SourceName": "User input",
                     "Start": 22
                   },
@@ -469,7 +469,7 @@
       "Source": {
         "End": 24,
         "Length": 23,
-        "Source": "\\pmatrix{2 & 2 \\\\ 2 & 2}",
+        "Source": "\\Bmatrix{2 & 2 \\\\ 2 & 2}",
         "SourceName": "User input",
         "Start": 1
       },
@@ -495,14 +495,14 @@
     {
       "Background": null,
       "Character": {
-        "Character": "´",
+        "Character": "o",
         "Font": "pack://application:,,,/WpfMath;component/Fonts/cmex10.ttf",
         "FontId": 2,
         "Metrics": {
           "Depth": 1.760019,
           "Height": 0.039999,
           "Italic": 0.0,
-          "Width": 0.597224
+          "Width": 0.666669
         },
         "Size": 1.0
       },
@@ -514,8 +514,8 @@
       "Shift": -1.11001,
       "Source": null,
       "TotalHeight": 1.800018,
-      "TotalWidth": 0.597224,
-      "Width": 0.597224
+      "TotalWidth": 0.666669,
+      "Width": 0.666669
     }
   ],
   "Depth": 0.744444,
@@ -526,11 +526,11 @@
   "Source": {
     "End": 24,
     "Length": 23,
-    "Source": "\\pmatrix{2 & 2 \\\\ 2 & 2}",
+    "Source": "\\Bmatrix{2 & 2 \\\\ 2 & 2}",
     "SourceName": "User input",
     "Start": 1
   },
   "TotalHeight": 1.988888,
-  "TotalWidth": 2.894452,
-  "Width": 2.894452
+  "TotalWidth": 3.033342,
+  "Width": 3.033342
 }

--- a/src/WpfMath.Tests/TestResults/BoxTests.vMatrixBox.approved.txt
+++ b/src/WpfMath.Tests/TestResults/BoxTests.vMatrixBox.approved.txt
@@ -3,28 +3,92 @@
   "Children": [
     {
       "Background": null,
-      "Character": {
-        "Character": "³",
-        "Font": "pack://application:,,,/WpfMath;component/Fonts/cmex10.ttf",
-        "FontId": 2,
-        "Metrics": {
-          "Depth": 1.760019,
-          "Height": 0.039999,
+      "Children": [
+        {
+          "Background": null,
+          "Character": {
+            "Character": "¯",
+            "Font": "pack://application:,,,/WpfMath;component/Fonts/cmex10.ttf",
+            "FontId": 2,
+            "Metrics": {
+              "Depth": 0.600006,
+              "Height": 0.0,
+              "Italic": 0.0,
+              "Width": 0.333334
+            },
+            "Size": 1.0
+          },
+          "Children": [],
+          "Depth": 0.600006,
+          "Foreground": null,
+          "Height": 0.0,
           "Italic": 0.0,
-          "Width": 0.597224
+          "Shift": 0.0,
+          "Source": null,
+          "TotalHeight": 0.600006,
+          "TotalWidth": 0.333334,
+          "Width": 0.333334
         },
-        "Size": 1.0
-      },
-      "Children": [],
-      "Depth": 1.760019,
+        {
+          "Background": null,
+          "Character": {
+            "Character": "¯",
+            "Font": "pack://application:,,,/WpfMath;component/Fonts/cmex10.ttf",
+            "FontId": 2,
+            "Metrics": {
+              "Depth": 0.600006,
+              "Height": 0.0,
+              "Italic": 0.0,
+              "Width": 0.333334
+            },
+            "Size": 1.0
+          },
+          "Children": [],
+          "Depth": 0.600006,
+          "Foreground": null,
+          "Height": 0.0,
+          "Italic": 0.0,
+          "Shift": 0.0,
+          "Source": null,
+          "TotalHeight": 0.600006,
+          "TotalWidth": 0.333334,
+          "Width": 0.333334
+        },
+        {
+          "Background": null,
+          "Character": {
+            "Character": "¯",
+            "Font": "pack://application:,,,/WpfMath;component/Fonts/cmex10.ttf",
+            "FontId": 2,
+            "Metrics": {
+              "Depth": 0.600006,
+              "Height": 0.0,
+              "Italic": 0.0,
+              "Width": 0.333334
+            },
+            "Size": 1.0
+          },
+          "Children": [],
+          "Depth": 0.600006,
+          "Foreground": null,
+          "Height": 0.0,
+          "Italic": 0.0,
+          "Shift": 0.0,
+          "Source": null,
+          "TotalHeight": 0.600006,
+          "TotalWidth": 0.333334,
+          "Width": 0.333334
+        }
+      ],
+      "Depth": 1.800018,
       "Foreground": null,
-      "Height": 0.039999,
+      "Height": 0.0,
       "Italic": 0.0,
-      "Shift": -1.11001,
+      "Shift": -1.150009,
       "Source": null,
       "TotalHeight": 1.800018,
-      "TotalWidth": 0.597224,
-      "Width": 0.597224
+      "TotalWidth": 0.333334,
+      "Width": 0.333334
     },
     {
       "Background": null,
@@ -99,7 +163,7 @@
                   "Source": {
                     "End": 10,
                     "Length": 1,
-                    "Source": "\\pmatrix{2 & 2 \\\\ 2 & 2}",
+                    "Source": "\\vmatrix{2 & 2 \\\\ 2 & 2}",
                     "SourceName": "User input",
                     "Start": 9
                   },
@@ -196,7 +260,7 @@
                   "Source": {
                     "End": 14,
                     "Length": 1,
-                    "Source": "\\pmatrix{2 & 2 \\\\ 2 & 2}",
+                    "Source": "\\vmatrix{2 & 2 \\\\ 2 & 2}",
                     "SourceName": "User input",
                     "Start": 13
                   },
@@ -307,7 +371,7 @@
                   "Source": {
                     "End": 19,
                     "Length": 1,
-                    "Source": "\\pmatrix{2 & 2 \\\\ 2 & 2}",
+                    "Source": "\\vmatrix{2 & 2 \\\\ 2 & 2}",
                     "SourceName": "User input",
                     "Start": 18
                   },
@@ -404,7 +468,7 @@
                   "Source": {
                     "End": 23,
                     "Length": 1,
-                    "Source": "\\pmatrix{2 & 2 \\\\ 2 & 2}",
+                    "Source": "\\vmatrix{2 & 2 \\\\ 2 & 2}",
                     "SourceName": "User input",
                     "Start": 22
                   },
@@ -469,7 +533,7 @@
       "Source": {
         "End": 24,
         "Length": 23,
-        "Source": "\\pmatrix{2 & 2 \\\\ 2 & 2}",
+        "Source": "\\vmatrix{2 & 2 \\\\ 2 & 2}",
         "SourceName": "User input",
         "Start": 1
       },
@@ -494,28 +558,92 @@
     },
     {
       "Background": null,
-      "Character": {
-        "Character": "´",
-        "Font": "pack://application:,,,/WpfMath;component/Fonts/cmex10.ttf",
-        "FontId": 2,
-        "Metrics": {
-          "Depth": 1.760019,
-          "Height": 0.039999,
+      "Children": [
+        {
+          "Background": null,
+          "Character": {
+            "Character": "¯",
+            "Font": "pack://application:,,,/WpfMath;component/Fonts/cmex10.ttf",
+            "FontId": 2,
+            "Metrics": {
+              "Depth": 0.600006,
+              "Height": 0.0,
+              "Italic": 0.0,
+              "Width": 0.333334
+            },
+            "Size": 1.0
+          },
+          "Children": [],
+          "Depth": 0.600006,
+          "Foreground": null,
+          "Height": 0.0,
           "Italic": 0.0,
-          "Width": 0.597224
+          "Shift": 0.0,
+          "Source": null,
+          "TotalHeight": 0.600006,
+          "TotalWidth": 0.333334,
+          "Width": 0.333334
         },
-        "Size": 1.0
-      },
-      "Children": [],
-      "Depth": 1.760019,
+        {
+          "Background": null,
+          "Character": {
+            "Character": "¯",
+            "Font": "pack://application:,,,/WpfMath;component/Fonts/cmex10.ttf",
+            "FontId": 2,
+            "Metrics": {
+              "Depth": 0.600006,
+              "Height": 0.0,
+              "Italic": 0.0,
+              "Width": 0.333334
+            },
+            "Size": 1.0
+          },
+          "Children": [],
+          "Depth": 0.600006,
+          "Foreground": null,
+          "Height": 0.0,
+          "Italic": 0.0,
+          "Shift": 0.0,
+          "Source": null,
+          "TotalHeight": 0.600006,
+          "TotalWidth": 0.333334,
+          "Width": 0.333334
+        },
+        {
+          "Background": null,
+          "Character": {
+            "Character": "¯",
+            "Font": "pack://application:,,,/WpfMath;component/Fonts/cmex10.ttf",
+            "FontId": 2,
+            "Metrics": {
+              "Depth": 0.600006,
+              "Height": 0.0,
+              "Italic": 0.0,
+              "Width": 0.333334
+            },
+            "Size": 1.0
+          },
+          "Children": [],
+          "Depth": 0.600006,
+          "Foreground": null,
+          "Height": 0.0,
+          "Italic": 0.0,
+          "Shift": 0.0,
+          "Source": null,
+          "TotalHeight": 0.600006,
+          "TotalWidth": 0.333334,
+          "Width": 0.333334
+        }
+      ],
+      "Depth": 1.800018,
       "Foreground": null,
-      "Height": 0.039999,
+      "Height": 0.0,
       "Italic": 0.0,
-      "Shift": -1.11001,
+      "Shift": -1.150009,
       "Source": null,
       "TotalHeight": 1.800018,
-      "TotalWidth": 0.597224,
-      "Width": 0.597224
+      "TotalWidth": 0.333334,
+      "Width": 0.333334
     }
   ],
   "Depth": 0.744444,
@@ -526,11 +654,11 @@
   "Source": {
     "End": 24,
     "Length": 23,
-    "Source": "\\pmatrix{2 & 2 \\\\ 2 & 2}",
+    "Source": "\\vmatrix{2 & 2 \\\\ 2 & 2}",
     "SourceName": "User input",
     "Start": 1
   },
   "TotalHeight": 1.988888,
-  "TotalWidth": 2.894452,
-  "Width": 2.894452
+  "TotalWidth": 2.366672,
+  "Width": 2.366672
 }

--- a/src/WpfMath.Tests/TestResults/BoxTests.vvMatrixBox.approved.txt
+++ b/src/WpfMath.Tests/TestResults/BoxTests.vvMatrixBox.approved.txt
@@ -3,28 +3,92 @@
   "Children": [
     {
       "Background": null,
-      "Character": {
-        "Character": "³",
-        "Font": "pack://application:,,,/WpfMath;component/Fonts/cmex10.ttf",
-        "FontId": 2,
-        "Metrics": {
-          "Depth": 1.760019,
-          "Height": 0.039999,
+      "Children": [
+        {
+          "Background": null,
+          "Character": {
+            "Character": "°",
+            "Font": "pack://application:,,,/WpfMath;component/Fonts/cmex10.ttf",
+            "FontId": 2,
+            "Metrics": {
+              "Depth": 0.600006,
+              "Height": 0.0,
+              "Italic": 0.0,
+              "Width": 0.555557
+            },
+            "Size": 1.0
+          },
+          "Children": [],
+          "Depth": 0.600006,
+          "Foreground": null,
+          "Height": 0.0,
           "Italic": 0.0,
-          "Width": 0.597224
+          "Shift": 0.0,
+          "Source": null,
+          "TotalHeight": 0.600006,
+          "TotalWidth": 0.555557,
+          "Width": 0.555557
         },
-        "Size": 1.0
-      },
-      "Children": [],
-      "Depth": 1.760019,
+        {
+          "Background": null,
+          "Character": {
+            "Character": "°",
+            "Font": "pack://application:,,,/WpfMath;component/Fonts/cmex10.ttf",
+            "FontId": 2,
+            "Metrics": {
+              "Depth": 0.600006,
+              "Height": 0.0,
+              "Italic": 0.0,
+              "Width": 0.555557
+            },
+            "Size": 1.0
+          },
+          "Children": [],
+          "Depth": 0.600006,
+          "Foreground": null,
+          "Height": 0.0,
+          "Italic": 0.0,
+          "Shift": 0.0,
+          "Source": null,
+          "TotalHeight": 0.600006,
+          "TotalWidth": 0.555557,
+          "Width": 0.555557
+        },
+        {
+          "Background": null,
+          "Character": {
+            "Character": "°",
+            "Font": "pack://application:,,,/WpfMath;component/Fonts/cmex10.ttf",
+            "FontId": 2,
+            "Metrics": {
+              "Depth": 0.600006,
+              "Height": 0.0,
+              "Italic": 0.0,
+              "Width": 0.555557
+            },
+            "Size": 1.0
+          },
+          "Children": [],
+          "Depth": 0.600006,
+          "Foreground": null,
+          "Height": 0.0,
+          "Italic": 0.0,
+          "Shift": 0.0,
+          "Source": null,
+          "TotalHeight": 0.600006,
+          "TotalWidth": 0.555557,
+          "Width": 0.555557
+        }
+      ],
+      "Depth": 1.800018,
       "Foreground": null,
-      "Height": 0.039999,
+      "Height": 0.0,
       "Italic": 0.0,
-      "Shift": -1.11001,
+      "Shift": -1.150009,
       "Source": null,
       "TotalHeight": 1.800018,
-      "TotalWidth": 0.597224,
-      "Width": 0.597224
+      "TotalWidth": 0.555557,
+      "Width": 0.555557
     },
     {
       "Background": null,
@@ -99,7 +163,7 @@
                   "Source": {
                     "End": 10,
                     "Length": 1,
-                    "Source": "\\pmatrix{2 & 2 \\\\ 2 & 2}",
+                    "Source": "\\Vmatrix{2 & 2 \\\\ 2 & 2}",
                     "SourceName": "User input",
                     "Start": 9
                   },
@@ -196,7 +260,7 @@
                   "Source": {
                     "End": 14,
                     "Length": 1,
-                    "Source": "\\pmatrix{2 & 2 \\\\ 2 & 2}",
+                    "Source": "\\Vmatrix{2 & 2 \\\\ 2 & 2}",
                     "SourceName": "User input",
                     "Start": 13
                   },
@@ -307,7 +371,7 @@
                   "Source": {
                     "End": 19,
                     "Length": 1,
-                    "Source": "\\pmatrix{2 & 2 \\\\ 2 & 2}",
+                    "Source": "\\Vmatrix{2 & 2 \\\\ 2 & 2}",
                     "SourceName": "User input",
                     "Start": 18
                   },
@@ -404,7 +468,7 @@
                   "Source": {
                     "End": 23,
                     "Length": 1,
-                    "Source": "\\pmatrix{2 & 2 \\\\ 2 & 2}",
+                    "Source": "\\Vmatrix{2 & 2 \\\\ 2 & 2}",
                     "SourceName": "User input",
                     "Start": 22
                   },
@@ -469,7 +533,7 @@
       "Source": {
         "End": 24,
         "Length": 23,
-        "Source": "\\pmatrix{2 & 2 \\\\ 2 & 2}",
+        "Source": "\\Vmatrix{2 & 2 \\\\ 2 & 2}",
         "SourceName": "User input",
         "Start": 1
       },
@@ -494,28 +558,92 @@
     },
     {
       "Background": null,
-      "Character": {
-        "Character": "´",
-        "Font": "pack://application:,,,/WpfMath;component/Fonts/cmex10.ttf",
-        "FontId": 2,
-        "Metrics": {
-          "Depth": 1.760019,
-          "Height": 0.039999,
+      "Children": [
+        {
+          "Background": null,
+          "Character": {
+            "Character": "°",
+            "Font": "pack://application:,,,/WpfMath;component/Fonts/cmex10.ttf",
+            "FontId": 2,
+            "Metrics": {
+              "Depth": 0.600006,
+              "Height": 0.0,
+              "Italic": 0.0,
+              "Width": 0.555557
+            },
+            "Size": 1.0
+          },
+          "Children": [],
+          "Depth": 0.600006,
+          "Foreground": null,
+          "Height": 0.0,
           "Italic": 0.0,
-          "Width": 0.597224
+          "Shift": 0.0,
+          "Source": null,
+          "TotalHeight": 0.600006,
+          "TotalWidth": 0.555557,
+          "Width": 0.555557
         },
-        "Size": 1.0
-      },
-      "Children": [],
-      "Depth": 1.760019,
+        {
+          "Background": null,
+          "Character": {
+            "Character": "°",
+            "Font": "pack://application:,,,/WpfMath;component/Fonts/cmex10.ttf",
+            "FontId": 2,
+            "Metrics": {
+              "Depth": 0.600006,
+              "Height": 0.0,
+              "Italic": 0.0,
+              "Width": 0.555557
+            },
+            "Size": 1.0
+          },
+          "Children": [],
+          "Depth": 0.600006,
+          "Foreground": null,
+          "Height": 0.0,
+          "Italic": 0.0,
+          "Shift": 0.0,
+          "Source": null,
+          "TotalHeight": 0.600006,
+          "TotalWidth": 0.555557,
+          "Width": 0.555557
+        },
+        {
+          "Background": null,
+          "Character": {
+            "Character": "°",
+            "Font": "pack://application:,,,/WpfMath;component/Fonts/cmex10.ttf",
+            "FontId": 2,
+            "Metrics": {
+              "Depth": 0.600006,
+              "Height": 0.0,
+              "Italic": 0.0,
+              "Width": 0.555557
+            },
+            "Size": 1.0
+          },
+          "Children": [],
+          "Depth": 0.600006,
+          "Foreground": null,
+          "Height": 0.0,
+          "Italic": 0.0,
+          "Shift": 0.0,
+          "Source": null,
+          "TotalHeight": 0.600006,
+          "TotalWidth": 0.555557,
+          "Width": 0.555557
+        }
+      ],
+      "Depth": 1.800018,
       "Foreground": null,
-      "Height": 0.039999,
+      "Height": 0.0,
       "Italic": 0.0,
-      "Shift": -1.11001,
+      "Shift": -1.150009,
       "Source": null,
       "TotalHeight": 1.800018,
-      "TotalWidth": 0.597224,
-      "Width": 0.597224
+      "TotalWidth": 0.555557,
+      "Width": 0.555557
     }
   ],
   "Depth": 0.744444,
@@ -526,11 +654,11 @@
   "Source": {
     "End": 24,
     "Length": 23,
-    "Source": "\\pmatrix{2 & 2 \\\\ 2 & 2}",
+    "Source": "\\Vmatrix{2 & 2 \\\\ 2 & 2}",
     "SourceName": "User input",
     "Start": 1
   },
   "TotalHeight": 1.988888,
-  "TotalWidth": 2.894452,
-  "Width": 2.894452
+  "TotalWidth": 2.811118,
+  "Width": 2.811118
 }

--- a/src/WpfMath.Tests/TestResults/BoxTests.wideItemInMatrixBox.approved.txt
+++ b/src/WpfMath.Tests/TestResults/BoxTests.wideItemInMatrixBox.approved.txt
@@ -99,14 +99,14 @@
         {
           "Background": null,
           "Character": {
-            "Character": "·",
+            "Character": "µ",
             "Font": "pack://application:,,,/WpfMath;component/Fonts/cmex10.ttf",
             "FontId": 2,
             "Metrics": {
               "Depth": 2.360025,
               "Height": 0.039999,
               "Italic": 0.0,
-              "Width": 0.527781
+              "Width": 0.7361145
             },
             "Size": 1.0
           },
@@ -118,8 +118,8 @@
           "Shift": -1.410013,
           "Source": null,
           "TotalHeight": 2.400024,
-          "TotalWidth": 0.527781,
-          "Width": 0.527781
+          "TotalWidth": 0.7361145,
+          "Width": 0.7361145
         },
         {
           "Background": null,
@@ -1270,14 +1270,14 @@
         {
           "Background": null,
           "Character": {
-            "Character": "¸",
+            "Character": "¶",
             "Font": "pack://application:,,,/WpfMath;component/Fonts/cmex10.ttf",
             "FontId": 2,
             "Metrics": {
               "Depth": 2.360025,
               "Height": 0.039999,
               "Italic": 0.0,
-              "Width": 0.527781
+              "Width": 0.7361145
             },
             "Size": 1.0
           },
@@ -1289,8 +1289,8 @@
           "Shift": -1.410013,
           "Source": null,
           "TotalHeight": 2.400024,
-          "TotalWidth": 0.527781,
-          "Width": 0.527781
+          "TotalWidth": 0.7361145,
+          "Width": 0.7361145
         }
       ],
       "Depth": 0.9903354,
@@ -1306,8 +1306,8 @@
         "Start": 5
       },
       "TotalHeight": 2.4806708,
-      "TotalWidth": 8.1269474,
-      "Width": 8.1269474
+      "TotalWidth": 8.5436144,
+      "Width": 8.5436144
     }
   ],
   "Depth": 0.9903354,
@@ -1323,6 +1323,6 @@
     "Start": 4
   },
   "TotalHeight": 2.4806708,
-  "TotalWidth": 10.0318136222222,
-  "Width": 10.0318136222222
+  "TotalWidth": 10.4484806222222,
+  "Width": 10.4484806222222
 }

--- a/src/WpfMath.Tests/TestResults/EnvironmentTests.bMatrixEnvironment.approved.txt
+++ b/src/WpfMath.Tests/TestResults/EnvironmentTests.bMatrixEnvironment.approved.txt
@@ -1,0 +1,113 @@
+{
+  "RootAtom": {
+    "[AtomType]": "FencedAtom",
+    "BaseAtom": {
+      "[AtomType]": "MatrixAtom",
+      "HorizontalPadding": 0.35,
+      "MatrixCellAlignment": "Center",
+      "MatrixCells": [
+        [
+          {
+            "[AtomType]": "CharAtom",
+            "Character": "a",
+            "IsTextSymbol": false,
+            "Source": {
+              "End": 16,
+              "Length": 1,
+              "Source": "\\begin{bmatrix}a & b \\\\ c & d\\end{bmatrix}",
+              "SourceName": "User input",
+              "Start": 15
+            },
+            "TextStyle": null,
+            "Type": "Ordinary"
+          },
+          {
+            "[AtomType]": "CharAtom",
+            "Character": "b",
+            "IsTextSymbol": false,
+            "Source": {
+              "End": 20,
+              "Length": 1,
+              "Source": "\\begin{bmatrix}a & b \\\\ c & d\\end{bmatrix}",
+              "SourceName": "User input",
+              "Start": 19
+            },
+            "TextStyle": null,
+            "Type": "Ordinary"
+          }
+        ],
+        [
+          {
+            "[AtomType]": "CharAtom",
+            "Character": "c",
+            "IsTextSymbol": false,
+            "Source": {
+              "End": 25,
+              "Length": 1,
+              "Source": "\\begin{bmatrix}a & b \\\\ c & d\\end{bmatrix}",
+              "SourceName": "User input",
+              "Start": 24
+            },
+            "TextStyle": null,
+            "Type": "Ordinary"
+          },
+          {
+            "[AtomType]": "CharAtom",
+            "Character": "d",
+            "IsTextSymbol": false,
+            "Source": {
+              "End": 29,
+              "Length": 1,
+              "Source": "\\begin{bmatrix}a & b \\\\ c & d\\end{bmatrix}",
+              "SourceName": "User input",
+              "Start": 28
+            },
+            "TextStyle": null,
+            "Type": "Ordinary"
+          }
+        ]
+      ],
+      "Source": {
+        "End": 42,
+        "Length": 41,
+        "Source": "\\begin{bmatrix}a & b \\\\ c & d\\end{bmatrix}",
+        "SourceName": "User input",
+        "Start": 1
+      },
+      "Type": "Ordinary",
+      "VerticalPadding": 0.35
+    },
+    "LeftDelimeter": {
+      "[AtomType]": "SymbolAtom",
+      "IsDelimeter": true,
+      "IsTextSymbol": false,
+      "Name": "lbrack",
+      "Source": null,
+      "Type": "Opening"
+    },
+    "RightDelimeter": {
+      "[AtomType]": "SymbolAtom",
+      "IsDelimeter": true,
+      "IsTextSymbol": false,
+      "Name": "rbrack",
+      "Source": null,
+      "Type": "Closing"
+    },
+    "Source": {
+      "End": 42,
+      "Length": 41,
+      "Source": "\\begin{bmatrix}a & b \\\\ c & d\\end{bmatrix}",
+      "SourceName": "User input",
+      "Start": 1
+    },
+    "Type": "Ordinary"
+  },
+  "Source": {
+    "End": 42,
+    "Length": 42,
+    "Source": "\\begin{bmatrix}a & b \\\\ c & d\\end{bmatrix}",
+    "SourceName": "User input",
+    "Start": 0
+  },
+  "TextStyle": null
+}

--- a/src/WpfMath.Tests/TestResults/EnvironmentTests.bbMatrixEnvironment.approved.txt
+++ b/src/WpfMath.Tests/TestResults/EnvironmentTests.bbMatrixEnvironment.approved.txt
@@ -1,0 +1,113 @@
+{
+  "RootAtom": {
+    "[AtomType]": "FencedAtom",
+    "BaseAtom": {
+      "[AtomType]": "MatrixAtom",
+      "HorizontalPadding": 0.35,
+      "MatrixCellAlignment": "Center",
+      "MatrixCells": [
+        [
+          {
+            "[AtomType]": "CharAtom",
+            "Character": "a",
+            "IsTextSymbol": false,
+            "Source": {
+              "End": 16,
+              "Length": 1,
+              "Source": "\\begin{Bmatrix}a & b \\\\ c & d\\end{Bmatrix}",
+              "SourceName": "User input",
+              "Start": 15
+            },
+            "TextStyle": null,
+            "Type": "Ordinary"
+          },
+          {
+            "[AtomType]": "CharAtom",
+            "Character": "b",
+            "IsTextSymbol": false,
+            "Source": {
+              "End": 20,
+              "Length": 1,
+              "Source": "\\begin{Bmatrix}a & b \\\\ c & d\\end{Bmatrix}",
+              "SourceName": "User input",
+              "Start": 19
+            },
+            "TextStyle": null,
+            "Type": "Ordinary"
+          }
+        ],
+        [
+          {
+            "[AtomType]": "CharAtom",
+            "Character": "c",
+            "IsTextSymbol": false,
+            "Source": {
+              "End": 25,
+              "Length": 1,
+              "Source": "\\begin{Bmatrix}a & b \\\\ c & d\\end{Bmatrix}",
+              "SourceName": "User input",
+              "Start": 24
+            },
+            "TextStyle": null,
+            "Type": "Ordinary"
+          },
+          {
+            "[AtomType]": "CharAtom",
+            "Character": "d",
+            "IsTextSymbol": false,
+            "Source": {
+              "End": 29,
+              "Length": 1,
+              "Source": "\\begin{Bmatrix}a & b \\\\ c & d\\end{Bmatrix}",
+              "SourceName": "User input",
+              "Start": 28
+            },
+            "TextStyle": null,
+            "Type": "Ordinary"
+          }
+        ]
+      ],
+      "Source": {
+        "End": 42,
+        "Length": 41,
+        "Source": "\\begin{Bmatrix}a & b \\\\ c & d\\end{Bmatrix}",
+        "SourceName": "User input",
+        "Start": 1
+      },
+      "Type": "Ordinary",
+      "VerticalPadding": 0.35
+    },
+    "LeftDelimeter": {
+      "[AtomType]": "SymbolAtom",
+      "IsDelimeter": true,
+      "IsTextSymbol": false,
+      "Name": "lbrace",
+      "Source": null,
+      "Type": "Opening"
+    },
+    "RightDelimeter": {
+      "[AtomType]": "SymbolAtom",
+      "IsDelimeter": true,
+      "IsTextSymbol": false,
+      "Name": "rbrace",
+      "Source": null,
+      "Type": "Closing"
+    },
+    "Source": {
+      "End": 42,
+      "Length": 41,
+      "Source": "\\begin{Bmatrix}a & b \\\\ c & d\\end{Bmatrix}",
+      "SourceName": "User input",
+      "Start": 1
+    },
+    "Type": "Ordinary"
+  },
+  "Source": {
+    "End": 42,
+    "Length": 42,
+    "Source": "\\begin{Bmatrix}a & b \\\\ c & d\\end{Bmatrix}",
+    "SourceName": "User input",
+    "Start": 0
+  },
+  "TextStyle": null
+}

--- a/src/WpfMath.Tests/TestResults/EnvironmentTests.nestedEnvironment.approved.txt
+++ b/src/WpfMath.Tests/TestResults/EnvironmentTests.nestedEnvironment.approved.txt
@@ -201,7 +201,7 @@
               "[AtomType]": "SymbolAtom",
               "IsDelimeter": true,
               "IsTextSymbol": false,
-              "Name": "lbrack",
+              "Name": "(",
               "Source": null,
               "Type": "Opening"
             },
@@ -209,7 +209,7 @@
               "[AtomType]": "SymbolAtom",
               "IsDelimeter": true,
               "IsTextSymbol": false,
-              "Name": "rbrack",
+              "Name": ")",
               "Source": null,
               "Type": "Closing"
             },
@@ -238,7 +238,7 @@
       "[AtomType]": "SymbolAtom",
       "IsDelimeter": true,
       "IsTextSymbol": false,
-      "Name": "lbrack",
+      "Name": "(",
       "Source": null,
       "Type": "Opening"
     },
@@ -246,7 +246,7 @@
       "[AtomType]": "SymbolAtom",
       "IsDelimeter": true,
       "IsTextSymbol": false,
-      "Name": "rbrack",
+      "Name": ")",
       "Source": null,
       "Type": "Closing"
     },

--- a/src/WpfMath.Tests/TestResults/EnvironmentTests.nestedMatrix.approved.txt
+++ b/src/WpfMath.Tests/TestResults/EnvironmentTests.nestedMatrix.approved.txt
@@ -285,7 +285,7 @@
               "[AtomType]": "SymbolAtom",
               "IsDelimeter": true,
               "IsTextSymbol": false,
-              "Name": "lbrack",
+              "Name": "(",
               "Source": null,
               "Type": "Opening"
             },
@@ -293,7 +293,7 @@
               "[AtomType]": "SymbolAtom",
               "IsDelimeter": true,
               "IsTextSymbol": false,
-              "Name": "rbrack",
+              "Name": ")",
               "Source": null,
               "Type": "Closing"
             },
@@ -322,7 +322,7 @@
       "[AtomType]": "SymbolAtom",
       "IsDelimeter": true,
       "IsTextSymbol": false,
-      "Name": "lbrack",
+      "Name": "(",
       "Source": null,
       "Type": "Opening"
     },
@@ -330,7 +330,7 @@
       "[AtomType]": "SymbolAtom",
       "IsDelimeter": true,
       "IsTextSymbol": false,
-      "Name": "rbrack",
+      "Name": ")",
       "Source": null,
       "Type": "Closing"
     },

--- a/src/WpfMath.Tests/TestResults/EnvironmentTests.pMatrixEnvironment.approved.txt
+++ b/src/WpfMath.Tests/TestResults/EnvironmentTests.pMatrixEnvironment.approved.txt
@@ -206,7 +206,7 @@
       "[AtomType]": "SymbolAtom",
       "IsDelimeter": true,
       "IsTextSymbol": false,
-      "Name": "lbrack",
+      "Name": "(",
       "Source": null,
       "Type": "Opening"
     },
@@ -214,7 +214,7 @@
       "[AtomType]": "SymbolAtom",
       "IsDelimeter": true,
       "IsTextSymbol": false,
-      "Name": "rbrack",
+      "Name": ")",
       "Source": null,
       "Type": "Closing"
     },

--- a/src/WpfMath.Tests/TestResults/EnvironmentTests.vMatrixEnvironment.approved.txt
+++ b/src/WpfMath.Tests/TestResults/EnvironmentTests.vMatrixEnvironment.approved.txt
@@ -1,0 +1,113 @@
+{
+  "RootAtom": {
+    "[AtomType]": "FencedAtom",
+    "BaseAtom": {
+      "[AtomType]": "MatrixAtom",
+      "HorizontalPadding": 0.35,
+      "MatrixCellAlignment": "Center",
+      "MatrixCells": [
+        [
+          {
+            "[AtomType]": "CharAtom",
+            "Character": "a",
+            "IsTextSymbol": false,
+            "Source": {
+              "End": 16,
+              "Length": 1,
+              "Source": "\\begin{vmatrix}a & b \\\\ c & d\\end{vmatrix}",
+              "SourceName": "User input",
+              "Start": 15
+            },
+            "TextStyle": null,
+            "Type": "Ordinary"
+          },
+          {
+            "[AtomType]": "CharAtom",
+            "Character": "b",
+            "IsTextSymbol": false,
+            "Source": {
+              "End": 20,
+              "Length": 1,
+              "Source": "\\begin{vmatrix}a & b \\\\ c & d\\end{vmatrix}",
+              "SourceName": "User input",
+              "Start": 19
+            },
+            "TextStyle": null,
+            "Type": "Ordinary"
+          }
+        ],
+        [
+          {
+            "[AtomType]": "CharAtom",
+            "Character": "c",
+            "IsTextSymbol": false,
+            "Source": {
+              "End": 25,
+              "Length": 1,
+              "Source": "\\begin{vmatrix}a & b \\\\ c & d\\end{vmatrix}",
+              "SourceName": "User input",
+              "Start": 24
+            },
+            "TextStyle": null,
+            "Type": "Ordinary"
+          },
+          {
+            "[AtomType]": "CharAtom",
+            "Character": "d",
+            "IsTextSymbol": false,
+            "Source": {
+              "End": 29,
+              "Length": 1,
+              "Source": "\\begin{vmatrix}a & b \\\\ c & d\\end{vmatrix}",
+              "SourceName": "User input",
+              "Start": 28
+            },
+            "TextStyle": null,
+            "Type": "Ordinary"
+          }
+        ]
+      ],
+      "Source": {
+        "End": 42,
+        "Length": 41,
+        "Source": "\\begin{vmatrix}a & b \\\\ c & d\\end{vmatrix}",
+        "SourceName": "User input",
+        "Start": 1
+      },
+      "Type": "Ordinary",
+      "VerticalPadding": 0.35
+    },
+    "LeftDelimeter": {
+      "[AtomType]": "SymbolAtom",
+      "IsDelimeter": true,
+      "IsTextSymbol": false,
+      "Name": "vert",
+      "Source": null,
+      "Type": "Ordinary"
+    },
+    "RightDelimeter": {
+      "[AtomType]": "SymbolAtom",
+      "IsDelimeter": true,
+      "IsTextSymbol": false,
+      "Name": "vert",
+      "Source": null,
+      "Type": "Ordinary"
+    },
+    "Source": {
+      "End": 42,
+      "Length": 41,
+      "Source": "\\begin{vmatrix}a & b \\\\ c & d\\end{vmatrix}",
+      "SourceName": "User input",
+      "Start": 1
+    },
+    "Type": "Ordinary"
+  },
+  "Source": {
+    "End": 42,
+    "Length": 42,
+    "Source": "\\begin{vmatrix}a & b \\\\ c & d\\end{vmatrix}",
+    "SourceName": "User input",
+    "Start": 0
+  },
+  "TextStyle": null
+}

--- a/src/WpfMath.Tests/TestResults/EnvironmentTests.vvMatrixEnvironment.approved.txt
+++ b/src/WpfMath.Tests/TestResults/EnvironmentTests.vvMatrixEnvironment.approved.txt
@@ -1,0 +1,113 @@
+{
+  "RootAtom": {
+    "[AtomType]": "FencedAtom",
+    "BaseAtom": {
+      "[AtomType]": "MatrixAtom",
+      "HorizontalPadding": 0.35,
+      "MatrixCellAlignment": "Center",
+      "MatrixCells": [
+        [
+          {
+            "[AtomType]": "CharAtom",
+            "Character": "a",
+            "IsTextSymbol": false,
+            "Source": {
+              "End": 16,
+              "Length": 1,
+              "Source": "\\begin{Vmatrix}a & b \\\\ c & d\\end{Vmatrix}",
+              "SourceName": "User input",
+              "Start": 15
+            },
+            "TextStyle": null,
+            "Type": "Ordinary"
+          },
+          {
+            "[AtomType]": "CharAtom",
+            "Character": "b",
+            "IsTextSymbol": false,
+            "Source": {
+              "End": 20,
+              "Length": 1,
+              "Source": "\\begin{Vmatrix}a & b \\\\ c & d\\end{Vmatrix}",
+              "SourceName": "User input",
+              "Start": 19
+            },
+            "TextStyle": null,
+            "Type": "Ordinary"
+          }
+        ],
+        [
+          {
+            "[AtomType]": "CharAtom",
+            "Character": "c",
+            "IsTextSymbol": false,
+            "Source": {
+              "End": 25,
+              "Length": 1,
+              "Source": "\\begin{Vmatrix}a & b \\\\ c & d\\end{Vmatrix}",
+              "SourceName": "User input",
+              "Start": 24
+            },
+            "TextStyle": null,
+            "Type": "Ordinary"
+          },
+          {
+            "[AtomType]": "CharAtom",
+            "Character": "d",
+            "IsTextSymbol": false,
+            "Source": {
+              "End": 29,
+              "Length": 1,
+              "Source": "\\begin{Vmatrix}a & b \\\\ c & d\\end{Vmatrix}",
+              "SourceName": "User input",
+              "Start": 28
+            },
+            "TextStyle": null,
+            "Type": "Ordinary"
+          }
+        ]
+      ],
+      "Source": {
+        "End": 42,
+        "Length": 41,
+        "Source": "\\begin{Vmatrix}a & b \\\\ c & d\\end{Vmatrix}",
+        "SourceName": "User input",
+        "Start": 1
+      },
+      "Type": "Ordinary",
+      "VerticalPadding": 0.35
+    },
+    "LeftDelimeter": {
+      "[AtomType]": "SymbolAtom",
+      "IsDelimeter": true,
+      "IsTextSymbol": false,
+      "Name": "Vert",
+      "Source": null,
+      "Type": "Ordinary"
+    },
+    "RightDelimeter": {
+      "[AtomType]": "SymbolAtom",
+      "IsDelimeter": true,
+      "IsTextSymbol": false,
+      "Name": "Vert",
+      "Source": null,
+      "Type": "Ordinary"
+    },
+    "Source": {
+      "End": 42,
+      "Length": 41,
+      "Source": "\\begin{Vmatrix}a & b \\\\ c & d\\end{Vmatrix}",
+      "SourceName": "User input",
+      "Start": 1
+    },
+    "Type": "Ordinary"
+  },
+  "Source": {
+    "End": 42,
+    "Length": 42,
+    "Source": "\\begin{Vmatrix}a & b \\\\ c & d\\end{Vmatrix}",
+    "SourceName": "User input",
+    "Start": 0
+  },
+  "TextStyle": null
+}

--- a/src/WpfMath.Tests/TestResults/ParserTests.bigMatrixExpression.approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.bigMatrixExpression.approved.txt
@@ -425,7 +425,7 @@
                   "[AtomType]": "SymbolAtom",
                   "IsDelimeter": true,
                   "IsTextSymbol": false,
-                  "Name": "lbrack",
+                  "Name": "(",
                   "Source": null,
                   "Type": "Opening"
                 },
@@ -433,7 +433,7 @@
                   "[AtomType]": "SymbolAtom",
                   "IsDelimeter": true,
                   "IsTextSymbol": false,
-                  "Name": "rbrack",
+                  "Name": ")",
                   "Source": null,
                   "Type": "Closing"
                 },
@@ -890,7 +890,7 @@
                   "[AtomType]": "SymbolAtom",
                   "IsDelimeter": true,
                   "IsTextSymbol": false,
-                  "Name": "lbrack",
+                  "Name": "(",
                   "Source": null,
                   "Type": "Opening"
                 },
@@ -898,7 +898,7 @@
                   "[AtomType]": "SymbolAtom",
                   "IsDelimeter": true,
                   "IsTextSymbol": false,
-                  "Name": "rbrack",
+                  "Name": ")",
                   "Source": null,
                   "Type": "Closing"
                 },
@@ -1391,7 +1391,7 @@
                   "[AtomType]": "SymbolAtom",
                   "IsDelimeter": true,
                   "IsTextSymbol": false,
-                  "Name": "lbrack",
+                  "Name": "(",
                   "Source": null,
                   "Type": "Opening"
                 },
@@ -1399,7 +1399,7 @@
                   "[AtomType]": "SymbolAtom",
                   "IsDelimeter": true,
                   "IsTextSymbol": false,
-                  "Name": "rbrack",
+                  "Name": ")",
                   "Source": null,
                   "Type": "Closing"
                 },
@@ -1428,7 +1428,7 @@
           "[AtomType]": "SymbolAtom",
           "IsDelimeter": true,
           "IsTextSymbol": false,
-          "Name": "lbrack",
+          "Name": "(",
           "Source": null,
           "Type": "Opening"
         },
@@ -1436,7 +1436,7 @@
           "[AtomType]": "SymbolAtom",
           "IsDelimeter": true,
           "IsTextSymbol": false,
-          "Name": "rbrack",
+          "Name": ")",
           "Source": null,
           "Type": "Closing"
         },

--- a/src/WpfMath.Tests/TestResults/ParserTests.newLineAfterMatrix.(pmatrix(line 1)line 2).approved.txt
+++ b/src/WpfMath.Tests/TestResults/ParserTests.newLineAfterMatrix.(pmatrix(line 1)line 2).approved.txt
@@ -113,7 +113,7 @@
             "[AtomType]": "SymbolAtom",
             "IsDelimeter": true,
             "IsTextSymbol": false,
-            "Name": "lbrack",
+            "Name": "(",
             "Source": null,
             "Type": "Opening"
           },
@@ -121,7 +121,7 @@
             "[AtomType]": "SymbolAtom",
             "IsDelimeter": true,
             "IsTextSymbol": false,
-            "Name": "rbrack",
+            "Name": ")",
             "Source": null,
             "Type": "Closing"
           },

--- a/src/XamlMath.Shared/Parsers/Matrices/MatrixCommandParser.cs
+++ b/src/XamlMath.Shared/Parsers/Matrices/MatrixCommandParser.cs
@@ -11,7 +11,11 @@ internal sealed class MatrixCommandParser : ICommandParser, IEnvironmentParser
     internal static readonly MatrixCommandParser Align = new(null, null, MatrixCellAlignment.Aligned);
     internal static readonly MatrixCommandParser Cases = new("lbrace", null, MatrixCellAlignment.Left);
     internal static readonly MatrixCommandParser Matrix = new(null, null, MatrixCellAlignment.Center);
-    internal static readonly MatrixCommandParser PMatrix = new("lbrack", "rbrack", MatrixCellAlignment.Center);
+    internal static readonly MatrixCommandParser PMatrix = new("(", ")", MatrixCellAlignment.Center); // \pmatrix ( )
+    internal static readonly MatrixCommandParser BMatrix = new("lbrack", "rbrack", MatrixCellAlignment.Center); // \bmatrix [ ]
+    internal static readonly MatrixCommandParser BbMatrix = new("lbrace", "rbrace", MatrixCellAlignment.Center); // \Bmatrix { }
+    internal static readonly MatrixCommandParser VMatrix = new("vert", "vert", MatrixCellAlignment.Center); // \vmatrix | |
+    internal static readonly MatrixCommandParser VvMatrix = new("Vert", "Vert", MatrixCellAlignment.Center); // \Vmatrix ‖ ‖
 
     private readonly string? _leftDelimiterSymbolName;
     private readonly string? _rightDelimiterSymbolName;

--- a/src/XamlMath.Shared/Parsers/StandardCommands.cs
+++ b/src/XamlMath.Shared/Parsers/StandardCommands.cs
@@ -145,6 +145,10 @@ internal static class StandardCommands
             ["cases"] = MatrixCommandParser.Cases,
             ["matrix"] = MatrixCommandParser.Matrix,
             ["pmatrix"] = MatrixCommandParser.PMatrix,
+            ["bmatrix"] = MatrixCommandParser.BMatrix,
+            ["Bmatrix"] = MatrixCommandParser.BbMatrix,
+            ["vmatrix"] = MatrixCommandParser.VMatrix,
+            ["Vmatrix"] = MatrixCommandParser.VvMatrix,
             ["underline"] = new UnderlineCommand(),
             ["begin"] = new ProcessEnvironmentCommand()
         };
@@ -153,6 +157,10 @@ internal static class StandardCommands
         new Dictionary<string, IEnvironmentParser>
         {
             ["align"] = MatrixCommandParser.Align,
-            ["pmatrix"] = MatrixCommandParser.PMatrix
+            ["pmatrix"] = MatrixCommandParser.PMatrix,
+            ["bmatrix"] = MatrixCommandParser.BMatrix,
+            ["Bmatrix"] = MatrixCommandParser.BbMatrix,
+            ["vmatrix"] = MatrixCommandParser.VMatrix,
+            ["Vmatrix"] = MatrixCommandParser.VvMatrix
         };
 }


### PR DESCRIPTION
## New
Adds the amsmath matrix delimiter environments ([#201](https://github.com/ForNeVeR/xaml-math/issues/201)), each usable both as a command
(`\bmatrix{ … }`) and as an environment (`\begin{bmatrix} … \end{bmatrix}`):

| Env | Delimiters |
|-----|-----------|
| `bmatrix` | `[ ]` square brackets |
| `Bmatrix` | `{ }` curly braces |
| `vmatrix` | `\| \|` single vertical bars |
| `Vmatrix` | `‖ ‖` double vertical bars |

## Fix

`pmatrix` was wired to the `lbrack`/`rbrack` delimiters, so it rendered **square
brackets** rather than parentheses. Corrected to `(` / `)` to match LaTeX — which
also makes it distinct from the new `bmatrix`.

## Tests & Docs
- new tests for each variant
- updated pmatrix tests
- Updated `CHANGELOG.md`, `docs/matrices.md`, `docs/environments.md`
