### PR TITLE
Add the missing Latex command

### DIFF
--- a/src/WpfMath.Tests/AdditionalCommandTests.fs
+++ b/src/WpfMath.Tests/AdditionalCommandTests.fs
@@ -1,0 +1,140 @@
+module WpfMath.Tests.AdditionalCommandTests
+
+open Xunit
+open WpfMath.Parsers
+open WpfMath.Rendering
+open XamlMath
+open XamlMath.Atoms
+open XamlMath.Parsers
+
+let private parser = WpfTeXFormulaParser.Instance
+
+let private parse (formula: string) : Atom =
+    let result = parser.Parse formula
+    result.RootAtom
+
+let private environment = WpfTeXEnvironment.Create()
+
+// ──────────────────────────────────────────────────
+// 1. \textcolor alias for \color
+// ──────────────────────────────────────────────────
+
+[<Fact>]
+let ``TextColor parses like Color``() =
+    let atom = parse @"\textcolor{red}{x}"
+    Assert.NotNull atom
+
+[<Fact>]
+let ``TextColor with RGB model``() =
+    let atom = parse @"\textcolor[RGB]{255,0,0}{text}"
+    Assert.NotNull atom
+
+// ──────────────────────────────────────────────────
+// 2. More extensible arrows
+// ──────────────────────────────────────────────────
+
+[<Fact>]
+let ``XMapsto parses``() =
+    let atom = parse @"\xmapsto{a}" :?> ExtensibleArrowAtom
+    Assert.NotNull atom
+    Assert.Equal(ExtensibleArrowDirection.Right, atom.Direction)
+
+[<Fact>]
+let ``XHookrightarrow parses``() =
+    let atom = parse @"\xhookrightarrow{a}" :?> ExtensibleArrowAtom
+    Assert.NotNull atom
+
+[<Fact>]
+let ``XRightarrow parses``() =
+    let atom = parse @"\xRightarrow{a}" :?> ExtensibleArrowAtom
+    Assert.NotNull atom
+
+[<Fact>]
+let ``XLeftarrow parses``() =
+    let atom = parse @"\xLeftarrow{a}" :?> ExtensibleArrowAtom
+    Assert.Equal(ExtensibleArrowDirection.Left, atom.Direction)
+
+[<Fact>]
+let ``XHookleftarrow parses``() =
+    let atom = parse @"\xhookleftarrow{a}" :?> ExtensibleArrowAtom
+    Assert.NotNull atom
+
+// ──────────────────────────────────────────────────
+// 3. \gathered environment
+// ──────────────────────────────────────────────────
+
+[<Fact>]
+let ``Gathered environment parses``() =
+    let f = parser.Parse @"\begin{gathered}a=b\\c=d\end{gathered}"
+    Assert.NotNull f.RootAtom
+
+// ──────────────────────────────────────────────────
+// 4. \smallmatrix environment (inline)
+// ──────────────────────────────────────────────────
+
+[<Fact>]
+let ``SmallMatrix parses``() =
+    let f = parser.Parse @"\begin{smallmatrix}a&b\\c&d\end{smallmatrix}"
+    Assert.NotNull f.RootAtom
+
+// ──────────────────────────────────────────────────
+// 5. \intertext
+// ──────────────────────────────────────────────────
+
+[<Fact>]
+let ``Intertext parses in align``() =
+    let f = parser.Parse @"\begin{align}a&=b\\\intertext{text}c&=d\end{align}"
+    Assert.NotNull f.RootAtom
+
+// ──────────────────────────────────────────────────
+// 6. \mathclap / \mathrlap / \mathllap
+// ──────────────────────────────────────────────────
+
+[<Fact>]
+let ``MathClap parses``() =
+    let atom = parse @"\mathclap{x}"
+    Assert.NotNull atom
+
+[<Fact>]
+let ``MathRlap parses``() =
+    let atom = parse @"\mathrlap{x}"
+    Assert.NotNull atom
+
+[<Fact>]
+let ``MathLlap parses``() =
+    let atom = parse @"\mathllap{x}"
+    Assert.NotNull atom
+
+// ──────────────────────────────────────────────────
+// 7. \left. and \right. (empty delimiters)
+// ──────────────────────────────────────────────────
+
+[<Fact>]
+let ``Empty left delimiter``() =
+    let atom = parse @"\left.a\right)"
+    Assert.NotNull atom
+
+[<Fact>]
+let ``Empty right delimiter``() =
+    let atom = parse @"\left(\right."
+    Assert.NotNull atom
+
+[<Fact>]
+let ``Both empty delimiters``() =
+    let atom = parse @"\left.\right."
+    Assert.NotNull atom
+
+// ──────────────────────────────────────────────────
+// 8. Rendering smoke tests
+// ──────────────────────────────────────────────────
+
+[<Theory>]
+[<InlineData(@"\textcolor{red}{x}")>]
+[<InlineData(@"\xmapsto{a}")>]
+[<InlineData(@"\begin{gathered}a=b\\c=d\end{gathered}")>]
+[<InlineData(@"\mathclap{x}")>]
+[<InlineData(@"\left.\right)")>]
+let ``New commands render without crashing``(formula: string) =
+    let atom = parse formula
+    let box = atom.CreateBox(environment)
+    Assert.True(box.Width >= 0.0)

--- a/src/WpfMath.Tests/NewCommandTests.fs
+++ b/src/WpfMath.Tests/NewCommandTests.fs
@@ -1,0 +1,258 @@
+module WpfMath.Tests.NewCommandTests
+
+open Xunit
+open WpfMath.Parsers
+open WpfMath.Rendering
+open WpfMath.Tests.ApprovalTestUtils
+open XamlMath
+open XamlMath.Atoms
+open XamlMath.Parsers
+
+let private parser = WpfTeXFormulaParser.Instance
+
+/// Parses a formula and returns the root atom, or raises on error.
+let private parse (formula: string) : Atom =
+    let result = parser.Parse formula
+    result.RootAtom
+
+let private environment = WpfTeXEnvironment.Create()
+
+// ──────────────────────────────────────────────────
+// 1. Font Variant Commands (11)
+// ──────────────────────────────────────────────────
+
+[<Theory>]
+[<InlineData(@"\mathbb{R}")>]
+[<InlineData(@"\mathbf{v}")>]
+[<InlineData(@"\mathsf{ABC}")>]
+[<InlineData(@"\mathtt{abc}")>]
+[<InlineData(@"\mathfrak{g}")>]
+[<InlineData(@"\mathscr{L}")>]
+[<InlineData(@"\textbf{bold}")>]
+[<InlineData(@"\textit{italic}")>]
+[<InlineData(@"\textsf{sans}")>]
+[<InlineData(@"\texttt{type}")>]
+[<InlineData(@"\textsc{SmallCaps}")>]
+let ``Font variants parse successfully``(formula: string) =
+    let atom = parse formula
+    Assert.NotNull atom
+
+[<Theory>]
+[<InlineData(@"\mathbb{R} + \mathbb{C}")>]
+[<InlineData(@"\mathbf{a} \cdot \mathbf{b}")>]
+let ``Font variants work in expressions``(formula: string) =
+    let atom = parse formula
+    Assert.NotNull atom
+
+// ──────────────────────────────────────────────────
+// 2. Display Style Commands (4)
+// ──────────────────────────────────────────────────
+
+let rec private containsStyleAtom (targetStyle: TexStyle) (atom: Atom) : bool =
+    match atom with
+    | :? StyleAtom as sa -> sa.TargetStyle = targetStyle
+    | :? RowAtom as row ->
+        row.Elements
+        |> Seq.exists (fun e -> e <> null && containsStyleAtom targetStyle e)
+    | :? BigOperatorAtom as bigOp ->
+        bigOp.BaseAtom <> null && containsStyleAtom targetStyle bigOp.BaseAtom
+    | :? ScriptsAtom as scripts ->
+        scripts.BaseAtom <> null && containsStyleAtom targetStyle scripts.BaseAtom
+    | :? UnderOverAtom as uo ->
+        uo.BaseAtom <> null && containsStyleAtom targetStyle uo.BaseAtom
+    | :? FencedAtom as fenced ->
+        containsStyleAtom targetStyle fenced.BaseAtom
+    | _ -> false
+
+[<Theory>]
+[<InlineData(@"\displaystyle\int_0^1 x\,dx", TexStyle.Display)>]
+[<InlineData(@"\textstyle\sum_{i=1}^n", TexStyle.Text)>]
+[<InlineData(@"\scriptstyle x^2", TexStyle.Script)>]
+[<InlineData(@"\scriptscriptstyle x", TexStyle.ScriptScript)>]
+let ``Display style commands produce correct StyleAtom``(formula: string, expectedStyle: TexStyle) =
+    let atom = parse formula
+    Assert.True(containsStyleAtom expectedStyle atom,
+        sprintf "Expected StyleAtom with style %A in the atom tree" expectedStyle)
+
+[<Fact>]
+let ``Display style with grouped content``() =
+    let atom = parse @"\displaystyle {\int_0^1 f(x)\,dx}"
+    Assert.True(containsStyleAtom TexStyle.Display atom)
+
+// ──────────────────────────────────────────────────
+// 3. Stacked Annotation Commands (3)
+// ──────────────────────────────────────────────────
+
+[<Fact>]
+let ``Overset creates UnderOverAtom``() =
+    let atom = parse @"\overset{*}{X}" :?> UnderOverAtom
+    Assert.NotNull atom.OverAtom
+    Assert.Null atom.UnderAtom
+    Assert.NotNull atom.BaseAtom
+
+[<Fact>]
+let ``Underset creates UnderOverAtom``() =
+    let atom = parse @"\underset{i=1}{\bigcap}" :?> UnderOverAtom
+    Assert.Null atom.OverAtom
+    Assert.NotNull atom.UnderAtom
+    Assert.NotNull atom.BaseAtom
+
+[<Fact>]
+let ``Stackrel creates UnderOverAtom``() =
+    let atom = parse @"\stackrel{!}{=}" :?> UnderOverAtom
+    Assert.NotNull atom.OverAtom
+    Assert.Null atom.UnderAtom
+    Assert.NotNull atom.BaseAtom
+
+// ──────────────────────────────────────────────────
+// 4. Invisible Atom Commands (4)
+// ──────────────────────────────────────────────────
+
+[<Fact>]
+let ``Phantom creates PhantomAtom``() =
+    let atom = parse @"\phantom{x+y}" :?> PhantomAtom
+    Assert.NotNull atom.RowAtom
+
+[<Fact>]
+let ``HPhantom creates PhantomAtom``() =
+    let atom = parse @"\hphantom{x}" :?> PhantomAtom
+    Assert.NotNull atom
+
+[<Fact>]
+let ``VPhantom creates PhantomAtom``() =
+    let atom = parse @"\vphantom{x}" :?> PhantomAtom
+    Assert.NotNull atom
+
+[<Fact>]
+let ``Smash creates PhantomAtom``() =
+    let atom = parse @"\smash{x}" :?> PhantomAtom
+    Assert.NotNull atom
+
+// ──────────────────────────────────────────────────
+// 5. Box Command (1)
+// ──────────────────────────────────────────────────
+
+[<Fact>]
+let ``Boxed creates BoxedAtom``() =
+    let atom = parse @"\boxed{E=mc^2}" :?> BoxedAtom
+    Assert.NotNull atom.BaseAtom
+
+[<Fact>]
+let ``Boxed with complex content``() =
+    let atom = parse @"\boxed{\int_a^b f(x)\,dx}" :?> BoxedAtom
+    Assert.NotNull atom
+
+[<Fact>]
+let ``Boxed can render without crashing``() =
+    let atom = parse @"\boxed{E=mc^2}"
+    let box = atom.CreateBox(environment)
+    Assert.True(box.Width >= 0.0)
+    Assert.True(box.Height >= 0.0)
+
+// ──────────────────────────────────────────────────
+// 6. AMS Matrix Environments (5)
+// ──────────────────────────────────────────────────
+
+[<Theory>]
+[<InlineData(@"\begin{aligned}a&=b\\c&=d\end{aligned}")>]
+[<InlineData(@"\begin{bmatrix}1&2\\3&4\end{bmatrix}")>]
+[<InlineData(@"\begin{Bmatrix}1&2\\3&4\end{Bmatrix}")>]
+[<InlineData(@"\begin{vmatrix}1&2\\3&4\end{vmatrix}")>]
+[<InlineData(@"\begin{Vmatrix}1&2\\3&4\end{Vmatrix}")>]
+let ``AMS matrix environments parse successfully``(formula: string) =
+    let atom = parse formula
+    Assert.NotNull atom
+
+[<Fact>]
+let ``BMatrix with three rows``() =
+    let atom = parse @"\begin{bmatrix}a&b\\c&d\\e&f\end{bmatrix}"
+    Assert.NotNull atom
+
+[<Fact>]
+let ``VMatrix 3x3 determinant``() =
+    let atom = parse @"\begin{vmatrix}1&2&3\\4&5&6\\7&8&9\end{vmatrix}"
+    Assert.NotNull atom
+
+// ──────────────────────────────────────────────────
+// 7. Extensible Arrows (2)
+// ──────────────────────────────────────────────────
+
+[<Fact>]
+let ``XRightArrow creates ExtensibleArrowAtom``() =
+    let atom = parse @"\xrightarrow{n\to\infty}" :?> ExtensibleArrowAtom
+    Assert.Equal(ExtensibleArrowDirection.Right, atom.Direction)
+    Assert.NotNull atom.LabelAtom
+
+[<Fact>]
+let ``XLeftArrow creates ExtensibleArrowAtom``() =
+    let atom = parse @"\xleftarrow{n\to\infty}" :?> ExtensibleArrowAtom
+    Assert.Equal(ExtensibleArrowDirection.Left, atom.Direction)
+    Assert.NotNull atom.LabelAtom
+
+[<Fact>]
+let ``XRightArrow with empty label``() =
+    let atom = parse @"\xrightarrow{}" :?> ExtensibleArrowAtom
+    Assert.NotNull atom
+
+[<Fact>]
+let ``XRightArrow can render without crashing``() =
+    let atom = parse @"\xrightarrow{n\to\infty}"
+    let box = atom.CreateBox(environment)
+    Assert.True(box.Width >= 0.0)
+
+// ──────────────────────────────────────────────────
+// 8. AMS Abbreviations (3)
+// ──────────────────────────────────────────────────
+
+[<Fact>]
+let ``Implies parses``() =
+    let atom = parse @"A\implies B"
+    Assert.NotNull atom
+
+[<Fact>]
+let ``Iff parses``() =
+    let atom = parse @"A\iff B"
+    Assert.NotNull atom
+
+[<Fact>]
+let ``ImpliedBy parses``() =
+    let atom = parse @"A\impliedby B"
+    Assert.NotNull atom
+
+// ──────────────────────────────────────────────────
+// 9. Nested / Combined Commands
+// ──────────────────────────────────────────────────
+
+[<Fact>]
+let ``Boxed with mathbb``() =
+    let atom = parse @"\boxed{\mathbb{R}}" :?> BoxedAtom
+    Assert.NotNull atom
+
+[<Fact>]
+let ``Overset with scripts``() =
+    let atom = parse @"\overset{*}{\sum_{i=1}^n}" :?> UnderOverAtom
+    Assert.NotNull atom
+
+[<Fact>]
+let ``Phantom inside boxed``() =
+    let atom = parse @"\boxed{E = \phantom{x} mc^2}" :?> BoxedAtom
+    Assert.NotNull atom
+
+[<Fact>]
+let ``Matrix with boxed cell``() =
+    let atom = parse @"\begin{pmatrix}\boxed{a}&b\\c&d\end{pmatrix}"
+    Assert.NotNull atom
+
+// ──────────────────────────────────────────────────
+// 10. Approval-style rendering snapshot tests
+//    (verify JSON serialization of the atom tree)
+// ──────────────────────────────────────────────────
+
+[<Theory>]
+[<InlineData(@"\mathbb{R}", "mathbb")>]
+[<InlineData(@"\displaystyle\int_0^1 x\,dx", "displaystyle")>]
+[<InlineData(@"\overset{*}{X}", "overset")>]
+[<InlineData(@"\boxed{E=mc^2}", "boxed")>]
+[<InlineData(@"\xrightarrow{n\to\infty}", "xrightarrow")>]
+let ``New commands produce consistent atom trees``(formula: string, scenario: string) =
+    verifyParseResultScenario scenario formula

--- a/src/WpfMath.Tests/NewCommandTests.fs
+++ b/src/WpfMath.Tests/NewCommandTests.fs
@@ -244,6 +244,33 @@ let ``Matrix with boxed cell``() =
     Assert.NotNull atom
 
 // ──────────────────────────────────────────────────
+// 11. Additional standard LaTeX commands
+// ──────────────────────────────────────────────────
+
+[<Theory>]
+[<InlineData(@"\bmod")>]
+[<InlineData(@"\pmod{n}")>]
+[<InlineData(@"\dots")>]
+let ``Additional standard commands parse successfully``(formula: string) =
+    let atom = parse formula
+    Assert.NotNull atom
+
+[<Fact>]
+let ``Bmod is binary mod operator``() =
+    let f = parser.Parse @"a \bmod b"
+    Assert.NotNull f.RootAtom
+
+[<Fact>]
+let ``Pmod with argument``() =
+    let f = parser.Parse @"\pmod{n}"
+    Assert.NotNull f.RootAtom
+
+[<Fact>]
+let ``Dots equals ldots``() =
+    let atom = parse @"\dots"
+    Assert.NotNull atom
+
+// ──────────────────────────────────────────────────
 // 10. Approval-style rendering snapshot tests
 //    (verify JSON serialization of the atom tree)
 // ──────────────────────────────────────────────────

--- a/src/WpfMath.Tests/WpfMath.Tests.fsproj
+++ b/src/WpfMath.Tests/WpfMath.Tests.fsproj
@@ -36,6 +36,7 @@
         <Compile Include="GeometryElementRendererTests.fs" />
         <Compile Include="HorizontalBoxTests.fs" />
         <Compile Include="HorizontalRuleTests.fs" />
+        <Compile Include="NewCommandTests.fs" />
         <Compile Include="OverUnderBoxTests.fs" />
         <Compile Include="ParserTests.fs" />
         <Compile Include="ParserExceptionTests.fs" />

--- a/src/WpfMath.Tests/WpfMath.Tests.fsproj
+++ b/src/WpfMath.Tests/WpfMath.Tests.fsproj
@@ -27,6 +27,7 @@
     <ItemGroup>
         <Compile Include="ApprovalTestUtils.fs" />
         <Compile Include="Utils.fs" />
+        <Compile Include="AdditionalCommandTests.fs" />
         <Compile Include="BoxTests.fs" />
         <Compile Include="PredefinedColorParserTests.fs" />
         <Compile Include="CharBoxTests.fs" />

--- a/src/XamlMath.Shared/Atoms/BoxedAtom.cs
+++ b/src/XamlMath.Shared/Atoms/BoxedAtom.cs
@@ -1,0 +1,83 @@
+using XamlMath.Boxes;
+
+namespace XamlMath.Atoms;
+
+/// <summary>An atom representing a formula framed in a box, created by \boxed{...}.</summary>
+internal sealed record BoxedAtom : Atom
+{
+    private const double DefaultRuleThickness = 0.04; // relative to x-height
+    private const double DefaultPadding = 0.15; // relative to x-height
+
+    public BoxedAtom(SourceSpan? source, Atom? baseAtom)
+        : base(source)
+    {
+        BaseAtom = baseAtom ?? new NullAtom();
+    }
+
+    public Atom BaseAtom { get; }
+
+    protected override Box CreateBoxCore(TexEnvironment environment)
+    {
+        var baseBox = BaseAtom.CreateBox(environment);
+        var xHeight = environment.MathFont.GetXHeight(environment.Style, environment.LastFontId);
+        var ruleThickness = DefaultRuleThickness * xHeight;
+        var padding = DefaultPadding * xHeight;
+
+        // Total dimensions including padding and rules
+        var innerWidth = baseBox.Width + 2 * padding;
+        var innerHeight = baseBox.Height + padding + ruleThickness;
+        var innerDepth = baseBox.Depth + padding;
+
+        var totalWidth = innerWidth + 2 * ruleThickness;
+        var totalHeight = innerHeight + ruleThickness;
+        var totalDepth = innerDepth;
+
+        // Build the framed box
+        var resultBox = new VerticalBox();
+
+        // Top horizontal rule
+        resultBox.Add(new HorizontalRule(environment, ruleThickness, totalWidth, 0));
+
+        // Middle row: left rule + content + right rule
+        var middleRow = new HorizontalBox();
+        // left vertical rule spans the content height + depth
+        middleRow.Add(new HorizontalRule(environment, ruleThickness, ruleThickness, 0));
+        middleRow.Add(new StrutBox(ruleThickness, 0, 0, 0)); // gap between left rule and content
+
+        // Content with padding
+        var contentBox = new HorizontalBox();
+        contentBox.Add(new StrutBox(padding, 0, 0, 0));
+        contentBox.Add(baseBox);
+        contentBox.Add(new StrutBox(padding, 0, 0, 0));
+
+        // We need the content box to have the correct height + depth
+        // so the vertical rules extend the full height
+        contentBox.Height = innerHeight;
+        contentBox.Depth = innerDepth;
+        contentBox.Width = innerWidth;
+        middleRow.Add(contentBox);
+
+        middleRow.Add(new StrutBox(ruleThickness, 0, 0, 0)); // gap
+        middleRow.Add(new HorizontalRule(environment, ruleThickness, ruleThickness, 0));
+
+        // Set middle row height and depth to match content
+        middleRow.Height = innerHeight;
+        middleRow.Depth = innerDepth;
+        resultBox.Add(middleRow);
+
+        // Bottom horizontal rule
+        resultBox.Add(new HorizontalRule(environment, ruleThickness, totalWidth, 0));
+
+        // Make the top and bottom rules span the full width
+        // Adjust the result box dimensions
+        resultBox.Height = totalHeight;
+        resultBox.Depth = totalDepth;
+        resultBox.Width = totalWidth;
+
+        return resultBox;
+    }
+
+    public override TexAtomType GetLeftType() => TexAtomType.Ordinary;
+
+    public override TexAtomType GetRightType() => TexAtomType.Ordinary;
+}

--- a/src/XamlMath.Shared/Atoms/ExtensibleArrowAtom.cs
+++ b/src/XamlMath.Shared/Atoms/ExtensibleArrowAtom.cs
@@ -1,0 +1,134 @@
+using XamlMath.Boxes;
+using XamlMath.Parsers;
+
+namespace XamlMath.Atoms;
+
+/// <summary>An atom representing an extensible arrow with a label above, e.g. \xrightarrow{label}.</summary>
+internal sealed record ExtensibleArrowAtom : Atom
+{
+    private const double MinArrowWidth = 1.0; // Minimum arrow width in em-like units
+    private const double LabelPadding = 0.2; // Padding between label and arrow
+
+    public ExtensibleArrowAtom(
+        SourceSpan? source,
+        Atom? labelAtom,
+        ExtensibleArrowDirection direction)
+        : base(source)
+    {
+        LabelAtom = labelAtom;
+        Direction = direction;
+    }
+
+    public Atom? LabelAtom { get; }
+
+    public ExtensibleArrowDirection Direction { get; }
+
+    protected override Box CreateBoxCore(TexEnvironment environment)
+    {
+        // Create boxes for label and arrow
+        var labelBox = LabelAtom?.CreateBox(environment);
+        var labelWidth = labelBox?.Width ?? 0;
+
+        // Determine the arrow width: at least min width, and wide enough to cover the label
+        var arrowWidth = System.Math.Max(MinArrowWidth, labelWidth + 2 * LabelPadding);
+
+        // Find the appropriate arrow character
+        var arrowName = Direction == ExtensibleArrowDirection.Right ? "rightarrow" : "leftarrow";
+        var arrowChar = environment.MathFont.GetCharInfo(arrowName, environment.Style);
+        if (!arrowChar.IsSuccess)
+        {
+            // Fallback: use a fixed-width arrow box
+            return CreateFallbackBox(environment, labelBox, arrowWidth);
+        }
+
+        var arrowBox = new CharBox(environment, arrowChar.Value);
+        var arrowCharWidth = arrowBox.Width;
+
+        // We need to extend the arrow to match arrowWidth. 
+        // Use a repeated approach: if the character has a next-larger variant, use it.
+        // Otherwise, create a horizontal box with the arrow and extenders.
+        var resultBox = new VerticalBox();
+
+        // Place label above the arrow
+        if (labelBox != null)
+        {
+            // Center the label over the arrow
+            if (labelWidth < arrowWidth)
+            {
+                var centeredLabel = new HorizontalBox(labelBox, arrowWidth, TexAlignment.Center);
+                resultBox.Add(centeredLabel);
+            }
+            else
+            {
+                resultBox.Add(labelBox);
+                arrowWidth = labelWidth + 2 * LabelPadding;
+            }
+
+            // Add small space between label and arrow
+            resultBox.Add(new StrutBox(0, LabelPadding, 0, 0));
+        }
+
+        // Create the arrow line with arrowhead at the end
+        var arrowLineWidth = arrowWidth - arrowCharWidth;
+        if (arrowLineWidth < 0) arrowLineWidth = 0;
+
+        var arrowRow = new HorizontalBox();
+        if (Direction == ExtensibleArrowDirection.Right)
+        {
+            // Draw the arrow shaft then the arrowhead
+            if (arrowLineWidth > 0)
+            {
+                arrowRow.Add(CreateArrowShaft(environment, arrowLineWidth));
+            }
+            arrowRow.Add(arrowBox);
+        }
+        else
+        {
+            // Draw the arrowhead then the shaft
+            arrowRow.Add(arrowBox);
+            if (arrowLineWidth > 0)
+            {
+                arrowRow.Add(CreateArrowShaft(environment, arrowLineWidth));
+            }
+        }
+
+        arrowRow.Height = arrowBox.Height;
+        arrowRow.Depth = arrowBox.Depth;
+        arrowRow.Width = arrowWidth;
+        resultBox.Add(arrowRow);
+
+        return resultBox;
+    }
+
+    private static Box CreateArrowShaft(TexEnvironment environment, double width)
+    {
+        // Use a horizontal rule as the arrow shaft
+        var ruleThickness = environment.MathFont.GetDefaultLineThickness(environment.Style);
+        var shaftBox = new HorizontalRule(environment, ruleThickness, width, 0);
+        shaftBox.Height = ruleThickness;
+        shaftBox.Depth = 0;
+        return shaftBox;
+    }
+
+    private static Box CreateFallbackBox(TexEnvironment environment, Box? labelBox, double arrowWidth)
+    {
+        var resultBox = new VerticalBox();
+        var lineThickness = environment.MathFont.GetDefaultLineThickness(environment.Style);
+
+        if (labelBox != null)
+        {
+            var centeredLabel = new HorizontalBox(labelBox, arrowWidth, TexAlignment.Center);
+            resultBox.Add(centeredLabel);
+            resultBox.Add(new StrutBox(0, LabelPadding, 0, 0));
+        }
+
+        // Simple line with a small arrowhead approximation
+        var arrowLine = new HorizontalRule(environment, lineThickness, arrowWidth, 0);
+        resultBox.Add(arrowLine);
+        resultBox.Height = (labelBox?.Height ?? 0) + (labelBox != null ? LabelPadding : 0) + lineThickness;
+        resultBox.Depth = labelBox?.Depth ?? 0;
+        resultBox.Width = arrowWidth;
+
+        return resultBox;
+    }
+}

--- a/src/XamlMath.Shared/Atoms/StyleAtom.cs
+++ b/src/XamlMath.Shared/Atoms/StyleAtom.cs
@@ -1,0 +1,28 @@
+using XamlMath.Boxes;
+
+namespace XamlMath.Atoms;
+
+/// <summary>An atom that forces a specific <see cref="TexStyle"/> for its contents.</summary>
+internal sealed record StyleAtom : Atom
+{
+    public StyleAtom(SourceSpan? source, Atom? baseAtom, TexStyle targetStyle)
+        : base(source)
+    {
+        BaseAtom = baseAtom ?? new NullAtom();
+        TargetStyle = targetStyle;
+    }
+
+    public Atom BaseAtom { get; }
+
+    public TexStyle TargetStyle { get; }
+
+    protected override Box CreateBoxCore(TexEnvironment environment)
+    {
+        var newEnvironment = environment with { Style = TargetStyle };
+        return BaseAtom.CreateBox(newEnvironment);
+    }
+
+    public override TexAtomType GetLeftType() => BaseAtom.GetLeftType();
+
+    public override TexAtomType GetRightType() => BaseAtom.GetRightType();
+}

--- a/src/XamlMath.Shared/Data/DefaultTexFont.xml
+++ b/src/XamlMath.Shared/Data/DefaultTexFont.xml
@@ -64,6 +64,57 @@
     <TextStyleMapping name="mathcal">
       <MapRange code="capitals" fontId="3" start="65"/>
     </TextStyleMapping>
+    <TextStyleMapping name="mathbf">
+      <MapRange code="numbers" fontId="1" start="48"/>
+      <MapRange code="capitals" fontId="1" start="65"/>
+      <MapRange code="small" fontId="1" start="97"/>
+    </TextStyleMapping>
+    <TextStyleMapping name="mathbb">
+      <MapRange code="numbers" fontId="1" start="48"/>
+      <MapRange code="capitals" fontId="1" start="65"/>
+      <MapRange code="small" fontId="1" start="97"/>
+    </TextStyleMapping>
+    <TextStyleMapping name="mathsf">
+      <MapRange code="numbers" fontId="1" start="48"/>
+      <MapRange code="capitals" fontId="1" start="65"/>
+      <MapRange code="small" fontId="1" start="97"/>
+    </TextStyleMapping>
+    <TextStyleMapping name="mathtt">
+      <MapRange code="numbers" fontId="1" start="48"/>
+      <MapRange code="capitals" fontId="1" start="65"/>
+      <MapRange code="small" fontId="1" start="97"/>
+    </TextStyleMapping>
+    <TextStyleMapping name="mathfrak">
+      <MapRange code="numbers" fontId="1" start="48"/>
+      <MapRange code="capitals" fontId="1" start="65"/>
+      <MapRange code="small" fontId="1" start="97"/>
+    </TextStyleMapping>
+    <TextStyleMapping name="mathscr">
+      <MapRange code="capitals" fontId="3" start="65"/>
+    </TextStyleMapping>
+    <TextStyleMapping name="textbf">
+      <MapRange code="numbers" fontId="1" start="48"/>
+      <MapRange code="capitals" fontId="1" start="65"/>
+      <MapRange code="small" fontId="1" start="97"/>
+    </TextStyleMapping>
+    <TextStyleMapping name="textit">
+      <MapRange code="numbers" fontId="0" start="48"/>
+      <MapRange code="capitals" fontId="0" start="65"/>
+      <MapRange code="small" fontId="0" start="97"/>
+    </TextStyleMapping>
+    <TextStyleMapping name="textsf">
+      <MapRange code="numbers" fontId="1" start="48"/>
+      <MapRange code="capitals" fontId="1" start="65"/>
+      <MapRange code="small" fontId="1" start="97"/>
+    </TextStyleMapping>
+    <TextStyleMapping name="texttt">
+      <MapRange code="numbers" fontId="1" start="48"/>
+      <MapRange code="capitals" fontId="1" start="65"/>
+      <MapRange code="small" fontId="1" start="97"/>
+    </TextStyleMapping>
+    <TextStyleMapping name="textsc">
+      <MapRange code="capitals" fontId="1" start="65"/>
+    </TextStyleMapping>
   </TextStyleMappings>
 
   <!-- the default text style mappings, used when no text style is specified or when a specific mapping

--- a/src/XamlMath.Shared/Data/PredefinedTexFormulas.xml
+++ b/src/XamlMath.Shared/Data/PredefinedTexFormulas.xml
@@ -649,6 +649,30 @@
     <Return name="f" />
   </Formula>
 
+  <!-- bmod: binary mod operator -->
+
+  <Formula name="bmod" enabled="true">
+    <CreateFormula name="f" />
+    <MethodInvocation name="AddOperator" formula="f">
+      <Argument type="string" value="\mathrm{mod}" />
+      <Argument type="bool" value="false" />
+    </MethodInvocation>
+    <MethodInvocation name="SetFixedTypes" formula="f">
+      <Argument type="AtomType" value="BinaryOperator" />
+      <Argument type="AtomType" value="BinaryOperator" />
+    </MethodInvocation>
+    <Return name="f" />
+  </Formula>
+
+  <!-- dots: generic ellipsis (same as ldots) -->
+
+  <Formula name="dots" enabled="true">
+    <CreateFormula name="f">
+      <Argument type="string" value="\ldots" />
+    </CreateFormula>
+    <Return name="f" />
+  </Formula>
+
   <!-- AMS abbreviations -->
 
   <Formula name="implies" enabled="true">

--- a/src/XamlMath.Shared/Data/PredefinedTexFormulas.xml
+++ b/src/XamlMath.Shared/Data/PredefinedTexFormulas.xml
@@ -649,4 +649,39 @@
     <Return name="f" />
   </Formula>
 
+  <!-- AMS abbreviations -->
+
+  <Formula name="implies" enabled="true">
+    <CreateFormula name="f">
+      <Argument type="string" value="\Rightarrow" />
+    </CreateFormula>
+    <MethodInvocation name="SetFixedTypes" formula="f">
+      <Argument type="AtomType" value="Relation" />
+      <Argument type="AtomType" value="Relation" />
+    </MethodInvocation>
+    <Return name="f" />
+  </Formula>
+
+  <Formula name="iff" enabled="true">
+    <CreateFormula name="f">
+      <Argument type="string" value="\Leftrightarrow" />
+    </CreateFormula>
+    <MethodInvocation name="SetFixedTypes" formula="f">
+      <Argument type="AtomType" value="Relation" />
+      <Argument type="AtomType" value="Relation" />
+    </MethodInvocation>
+    <Return name="f" />
+  </Formula>
+
+  <Formula name="impliedby" enabled="true">
+    <CreateFormula name="f">
+      <Argument type="string" value="\Leftarrow" />
+    </CreateFormula>
+    <MethodInvocation name="SetFixedTypes" formula="f">
+      <Argument type="AtomType" value="Relation" />
+      <Argument type="AtomType" value="Relation" />
+    </MethodInvocation>
+    <Return name="f" />
+  </Formula>
+
 </PredefinedFormulas>

--- a/src/XamlMath.Shared/Data/TexFormulaSettings.xml
+++ b/src/XamlMath.Shared/Data/TexFormulaSettings.xml
@@ -40,6 +40,17 @@
     <TextStyle name="mathrm"/>
     <TextStyle name="mathit"/>
     <TextStyle name="mathcal"/>
+    <TextStyle name="mathbf"/>
+    <TextStyle name="mathbb"/>
+    <TextStyle name="mathsf"/>
+    <TextStyle name="mathtt"/>
+    <TextStyle name="mathfrak"/>
+    <TextStyle name="mathscr"/>
+    <TextStyle name="textbf"/>
+    <TextStyle name="textit"/>
+    <TextStyle name="textsf"/>
+    <TextStyle name="texttt"/>
+    <TextStyle name="textsc"/>
   </TextStyles>
 
   <!-- non-alphanumeric character-to-symbol-mappings -->

--- a/src/XamlMath.Shared/Parsers/ExtensibleArrowCommand.cs
+++ b/src/XamlMath.Shared/Parsers/ExtensibleArrowCommand.cs
@@ -1,0 +1,42 @@
+using XamlMath.Atoms;
+using XamlMath.Boxes;
+using XamlMath.Exceptions;
+
+namespace XamlMath.Parsers;
+
+internal enum ExtensibleArrowDirection
+{
+    Right,
+    Left
+}
+
+/// <summary>Parser for \xrightarrow{label} and \xleftarrow{label} commands.</summary>
+internal sealed class ExtensibleArrowCommand : ICommandParser
+{
+    private readonly ExtensibleArrowDirection _direction;
+
+    public ExtensibleArrowCommand(ExtensibleArrowDirection direction)
+    {
+        _direction = direction;
+    }
+
+    public CommandProcessingResult ProcessCommand(CommandContext context)
+    {
+        var source = context.CommandSource;
+        var position = context.ArgumentsStartPosition;
+        var start = context.CommandNameStartPosition;
+
+        var afterLabel = TexFormulaParser.ReadElement(source, position);
+        position = afterLabel.position;
+
+        var labelFormula = context.Parser.Parse(
+            afterLabel.source,
+            context.Formula.TextStyle,
+            context.Environment.CreateChildEnvironment());
+
+        var atomSource = source.Segment(start, position - start);
+        var atom = new ExtensibleArrowAtom(atomSource, labelFormula.RootAtom, _direction);
+
+        return new CommandProcessingResult(atom, position);
+    }
+}

--- a/src/XamlMath.Shared/Parsers/Matrices/IntertextCommand.cs
+++ b/src/XamlMath.Shared/Parsers/Matrices/IntertextCommand.cs
@@ -1,0 +1,50 @@
+using System.Collections.Generic;
+using System.Linq;
+using XamlMath.Atoms;
+using XamlMath.Exceptions;
+
+namespace XamlMath.Parsers.Matrices;
+
+/// <summary>Command for \intertext{...} inside align/gathered environments.</summary>
+internal sealed class IntertextCommand : ICommandParser
+{
+    private readonly List<List<Atom>> _rows;
+
+    public IntertextCommand(List<List<Atom>> rows)
+    {
+        _rows = rows;
+    }
+
+    public CommandProcessingResult ProcessCommand(CommandContext context)
+    {
+        var source = context.CommandSource;
+        var position = context.ArgumentsStartPosition;
+
+        // Read the text argument
+        var afterText = TexFormulaParser.ReadElement(source, position);
+        position = afterText.position;
+
+        // Parse the text content using \text style so it renders as normal text
+        var textFormula = context.Parser.Parse(
+            afterText.source,
+            "text",
+            context.Environment.CreateChildEnvironment());
+
+        if (textFormula.RootAtom == null)
+            throw new TexParseException("\\intertext requires text content");
+
+        // Finish the current cell
+        var currentAtom = context.Formula.RootAtom ?? new NullAtom();
+        context.Formula.RootAtom = null;
+        var lastRow = _rows.Last();
+        lastRow.Add(currentAtom);
+
+        // Add a new row with the intertext content
+        _rows.Add(new List<Atom> { textFormula.RootAtom });
+
+        // Start the next row
+        _rows.Add(new List<Atom>());
+
+        return new CommandProcessingResult(null, position);
+    }
+}

--- a/src/XamlMath.Shared/Parsers/Matrices/MatrixCommandParser.cs
+++ b/src/XamlMath.Shared/Parsers/Matrices/MatrixCommandParser.cs
@@ -16,6 +16,8 @@ internal sealed class MatrixCommandParser : ICommandParser, IEnvironmentParser
     internal static readonly MatrixCommandParser BMatrixBraces = new("lbrace", "rbrace", MatrixCellAlignment.Center);
     internal static readonly MatrixCommandParser VMatrix = new("vert", "vert", MatrixCellAlignment.Center);
     internal static readonly MatrixCommandParser VMatrixDouble = new("Vert", "Vert", MatrixCellAlignment.Center);
+    internal static readonly MatrixCommandParser Gathered = new(null, null, MatrixCellAlignment.Center);
+    internal static readonly MatrixCommandParser SmallMatrix = new(null, null, MatrixCellAlignment.Center);
 
     private readonly string? _leftDelimiterSymbolName;
     private readonly string? _rightDelimiterSymbolName;

--- a/src/XamlMath.Shared/Parsers/Matrices/MatrixCommandParser.cs
+++ b/src/XamlMath.Shared/Parsers/Matrices/MatrixCommandParser.cs
@@ -12,6 +12,10 @@ internal sealed class MatrixCommandParser : ICommandParser, IEnvironmentParser
     internal static readonly MatrixCommandParser Cases = new("lbrace", null, MatrixCellAlignment.Left);
     internal static readonly MatrixCommandParser Matrix = new(null, null, MatrixCellAlignment.Center);
     internal static readonly MatrixCommandParser PMatrix = new("lbrack", "rbrack", MatrixCellAlignment.Center);
+    internal static readonly MatrixCommandParser BMatrix = new("lbrack", "rbrack", MatrixCellAlignment.Center);
+    internal static readonly MatrixCommandParser BMatrixBraces = new("lbrace", "rbrace", MatrixCellAlignment.Center);
+    internal static readonly MatrixCommandParser VMatrix = new("vert", "vert", MatrixCellAlignment.Center);
+    internal static readonly MatrixCommandParser VMatrixDouble = new("Vert", "Vert", MatrixCellAlignment.Center);
 
     private readonly string? _leftDelimiterSymbolName;
     private readonly string? _rightDelimiterSymbolName;

--- a/src/XamlMath.Shared/Parsers/Matrices/MatrixInternalEnvironment.cs
+++ b/src/XamlMath.Shared/Parsers/Matrices/MatrixInternalEnvironment.cs
@@ -8,10 +8,12 @@ internal sealed class MatrixInternalEnvironment : NonRecursiveEnvironment
     private static IReadOnlyDictionary<string, ICommandParser> GetCommands(List<List<Atom>> rows)
     {
         var nextRowCommand = new NextRowCommand(rows);
+        var intertextCommand = new IntertextCommand(rows);
         return new Dictionary<string, ICommandParser>
         {
             [@"\"] = nextRowCommand,
-            ["cr"] = nextRowCommand
+            ["cr"] = nextRowCommand,
+            ["intertext"] = intertextCommand,
         };
     }
 

--- a/src/XamlMath.Shared/Parsers/StandardCommands.cs
+++ b/src/XamlMath.Shared/Parsers/StandardCommands.cs
@@ -149,6 +149,11 @@ internal static class StandardCommands
             ["begin"] = new ProcessEnvironmentCommand(),
             ["xrightarrow"] = new ExtensibleArrowCommand(ExtensibleArrowDirection.Right),
             ["xleftarrow"] = new ExtensibleArrowCommand(ExtensibleArrowDirection.Left),
+            ["xmapsto"] = new ExtensibleArrowCommand(ExtensibleArrowDirection.Right),
+            ["xhookrightarrow"] = new ExtensibleArrowCommand(ExtensibleArrowDirection.Right),
+            ["xRightarrow"] = new ExtensibleArrowCommand(ExtensibleArrowDirection.Right),
+            ["xLeftarrow"] = new ExtensibleArrowCommand(ExtensibleArrowDirection.Left),
+            ["xhookleftarrow"] = new ExtensibleArrowCommand(ExtensibleArrowDirection.Left),
         };
 
     internal static readonly IReadOnlyDictionary<string, IEnvironmentParser> Environments =
@@ -162,5 +167,7 @@ internal static class StandardCommands
             ["vmatrix"] = MatrixCommandParser.VMatrix,
             ["Vmatrix"] = MatrixCommandParser.VMatrixDouble,
             ["aligned"] = MatrixCommandParser.Align,
+            ["gathered"] = MatrixCommandParser.Gathered,
+            ["smallmatrix"] = MatrixCommandParser.SmallMatrix,
         };
 }

--- a/src/XamlMath.Shared/Parsers/StandardCommands.cs
+++ b/src/XamlMath.Shared/Parsers/StandardCommands.cs
@@ -146,13 +146,21 @@ internal static class StandardCommands
             ["matrix"] = MatrixCommandParser.Matrix,
             ["pmatrix"] = MatrixCommandParser.PMatrix,
             ["underline"] = new UnderlineCommand(),
-            ["begin"] = new ProcessEnvironmentCommand()
+            ["begin"] = new ProcessEnvironmentCommand(),
+            ["xrightarrow"] = new ExtensibleArrowCommand(ExtensibleArrowDirection.Right),
+            ["xleftarrow"] = new ExtensibleArrowCommand(ExtensibleArrowDirection.Left),
         };
 
     internal static readonly IReadOnlyDictionary<string, IEnvironmentParser> Environments =
         new Dictionary<string, IEnvironmentParser>
         {
             ["align"] = MatrixCommandParser.Align,
-            ["pmatrix"] = MatrixCommandParser.PMatrix
+            ["pmatrix"] = MatrixCommandParser.PMatrix,
+            ["matrix"] = MatrixCommandParser.Matrix,
+            ["bmatrix"] = MatrixCommandParser.BMatrix,
+            ["Bmatrix"] = MatrixCommandParser.BMatrixBraces,
+            ["vmatrix"] = MatrixCommandParser.VMatrix,
+            ["Vmatrix"] = MatrixCommandParser.VMatrixDouble,
+            ["aligned"] = MatrixCommandParser.Align,
         };
 }

--- a/src/XamlMath.Shared/TexFormulaParser.cs
+++ b/src/XamlMath.Shared/TexFormulaParser.cs
@@ -45,6 +45,7 @@ public class TexFormulaParser
         "overline",
         "overset",
         "phantom",
+        "pmod",
         "right",
         "scriptscriptstyle",
         "scriptstyle",
@@ -679,6 +680,36 @@ public class TexFormulaParser
                     return new Tuple<AtomAppendMode, Atom?>(
                         AtomAppendMode.Add,
                         new BoxedAtom(source, contentFormula.RootAtom));
+                }
+            case "pmod":
+                {
+                    // \pmod{n} renders as " (mod n)"
+                    var afterArg = ReadElement(value, position);
+                    position = afterArg.position;
+                    var argFormula = Parse(
+                        afterArg.source,
+                        formula.TextStyle,
+                        environment.CreateChildEnvironment());
+                    source = value.Segment(start, position - start);
+
+                    // Build " mod " prefix by parsing inline
+                    var modPrefixFormula = Parse(
+                        new SourceSpan(value.SourceName, @"\;\mathrm{mod}\;", 0, 14),
+                        formula.TextStyle,
+                        environment.CreateChildEnvironment());
+                    var modAtom = modPrefixFormula.RootAtom ?? new NullAtom(source);
+
+                    // Create a parenthesized atom: ( mod arg )
+                    var row = new RowAtom(null);
+                    row = row.Add(new SymbolAtom(source, "(", TexAtomType.Opening, true));
+                    row = row.Add(modAtom);
+                    if (argFormula.RootAtom != null)
+                        row = row.Add(argFormula.RootAtom);
+                    row = row.Add(new SymbolAtom(source, ")", TexAtomType.Closing, true));
+
+                    return new Tuple<AtomAppendMode, Atom?>(
+                        AtomAppendMode.Add,
+                        row);
                 }
         }
 

--- a/src/XamlMath.Shared/TexFormulaParser.cs
+++ b/src/XamlMath.Shared/TexFormulaParser.cs
@@ -35,13 +35,26 @@ public class TexFormulaParser
     /// </summary>
     private static readonly HashSet<string> embeddedCommands = new()
     {
+        "boxed",
         "color",
         "colorbox",
+        "displaystyle",
         "frac",
+        "hphantom",
         "left",
         "overline",
+        "overset",
+        "phantom",
         "right",
-        "sqrt"
+        "scriptscriptstyle",
+        "scriptstyle",
+        "smash",
+        "stackrel",
+        "sqrt",
+        "textstyle",
+        "underline",
+        "underset",
+        "vphantom",
     };
 
     private static readonly IReadOnlyList<string> symbols;
@@ -528,6 +541,144 @@ public class TexFormulaParser
                     return new Tuple<AtomAppendMode, Atom?>(
                         AtomAppendMode.Add,
                         new StyledAtom(source, bodyFormula.RootAtom, _brushFactory.FromColor(color), null));
+                }
+            case "overset":
+            case "underset":
+            case "stackrel":
+                {
+                    // All three read two elements: the annotation and the base.
+                    var isOverset = command == "overset";
+                    var isUnderset = command == "underset";
+                    var isStackrel = command == "stackrel";
+
+                    var afterAnnotation = ReadElement(value, position);
+                    position = afterAnnotation.position;
+                    var annotationFormula = Parse(
+                        afterAnnotation.source,
+                        formula.TextStyle,
+                        environment.CreateChildEnvironment());
+
+                    var afterBase = ReadElement(value, position);
+                    position = afterBase.position;
+                    var baseFormula = Parse(
+                        afterBase.source,
+                        formula.TextStyle,
+                        environment.CreateChildEnvironment());
+
+                    source = value.Segment(start, position - start);
+
+                    if (isStackrel)
+                    {
+                        // \stackrel{annotation}{base} — annotation over base, smaller
+                        return new Tuple<AtomAppendMode, Atom?>(
+                            AtomAppendMode.Add,
+                            new UnderOverAtom(
+                                source,
+                                baseFormula.RootAtom,
+                                null, // under
+                                TexUnit.Mu, 0, false,
+                                annotationFormula.RootAtom, // over
+                                TexUnit.Mu, 3, true));
+                    }
+                    else if (isOverset)
+                    {
+                        return new Tuple<AtomAppendMode, Atom?>(
+                            AtomAppendMode.Add,
+                            new UnderOverAtom(
+                                source,
+                                baseFormula.RootAtom,
+                                null, // under
+                                TexUnit.Mu, 0, false,
+                                annotationFormula.RootAtom, // over
+                                TexUnit.Mu, 3, true));
+                    }
+                    else // underset
+                    {
+                        return new Tuple<AtomAppendMode, Atom?>(
+                            AtomAppendMode.Add,
+                            new UnderOverAtom(
+                                source,
+                                baseFormula.RootAtom,
+                                annotationFormula.RootAtom, // under
+                                TexUnit.Mu, 3, true,
+                                null, // over
+                                TexUnit.Mu, 0, false));
+                    }
+                }
+            case "phantom":
+            case "hphantom":
+            case "vphantom":
+                {
+                    var afterContent = ReadElement(value, position);
+                    position = afterContent.position;
+                    var contentFormula = Parse(
+                        afterContent.source,
+                        formula.TextStyle,
+                        environment.CreateChildEnvironment());
+                    source = value.Segment(start, position - start);
+
+                    var useWidth = command != "vphantom";
+                    var useHeight = command != "hphantom";
+                    var useDepth = command != "hphantom";
+
+                    return new Tuple<AtomAppendMode, Atom?>(
+                        AtomAppendMode.Add,
+                        new PhantomAtom(source, contentFormula.RootAtom, useWidth, useHeight, useDepth));
+                }
+            case "smash":
+                {
+                    var afterContent = ReadElement(value, position);
+                    position = afterContent.position;
+                    var contentFormula = Parse(
+                        afterContent.source,
+                        formula.TextStyle,
+                        environment.CreateChildEnvironment());
+                    source = value.Segment(start, position - start);
+
+                    return new Tuple<AtomAppendMode, Atom?>(
+                        AtomAppendMode.Add,
+                        new PhantomAtom(source, contentFormula.RootAtom, true, false, false));
+                }
+            case "displaystyle":
+            case "textstyle":
+            case "scriptstyle":
+            case "scriptscriptstyle":
+                {
+                    var afterContent = ReadElement(value, position);
+                    position = afterContent.position;
+                    source = value.Segment(start, position - start);
+
+                    var targetStyle = command switch
+                    {
+                        "displaystyle" => TexStyle.Display,
+                        "textstyle" => TexStyle.Text,
+                        "scriptstyle" => TexStyle.Script,
+                        "scriptscriptstyle" => TexStyle.ScriptScript,
+                        _ => throw new TexParseException($"Invalid style command: {command}")
+                    };
+
+                    var contentFormula = Parse(
+                        afterContent.source,
+                        formula.TextStyle,
+                        environment.CreateChildEnvironment());
+
+                    return new Tuple<AtomAppendMode, Atom?>(
+                        AtomAppendMode.Add,
+                        new StyleAtom(source, contentFormula.RootAtom, targetStyle));
+                }
+            case "boxed":
+                {
+                    var afterContent = ReadElement(value, position);
+                    position = afterContent.position;
+                    var contentFormula = Parse(
+                        afterContent.source,
+                        formula.TextStyle,
+                        environment.CreateChildEnvironment());
+                    source = value.Segment(start, position - start);
+
+                    return new Tuple<AtomAppendMode, Atom?>(
+                        AtomAppendMode.Add,
+                        new BoxedAtom(source, contentFormula.RootAtom));
                 }
         }
 

--- a/src/XamlMath.Shared/TexFormulaParser.cs
+++ b/src/XamlMath.Shared/TexFormulaParser.cs
@@ -42,6 +42,9 @@ public class TexFormulaParser
         "frac",
         "hphantom",
         "left",
+        "mathclap",
+        "mathllap",
+        "mathrlap",
         "overline",
         "overset",
         "phantom",
@@ -52,6 +55,7 @@ public class TexFormulaParser
         "smash",
         "stackrel",
         "sqrt",
+        "textcolor",
         "textstyle",
         "underline",
         "underset",
@@ -516,6 +520,7 @@ public class TexFormulaParser
                         new Radical(source, sqrtFormula.RootAtom ?? new NullAtom(), degreeFormula?.RootAtom));
                 }
             case "color":
+            case "textcolor":
                 {
                     var color = ReadColorModelData(value, ref position);
 
@@ -680,6 +685,52 @@ public class TexFormulaParser
                     return new Tuple<AtomAppendMode, Atom?>(
                         AtomAppendMode.Add,
                         new BoxedAtom(source, contentFormula.RootAtom));
+                }
+            case "mathclap":
+                {
+                    var afterContent = ReadElement(value, position);
+                    position = afterContent.position;
+                    var contentFormula = Parse(
+                        afterContent.source,
+                        formula.TextStyle,
+                        environment.CreateChildEnvironment());
+                    source = value.Segment(start, position - start);
+
+                    // \mathclap makes content zero-width (centered)
+                    return new Tuple<AtomAppendMode, Atom?>(
+                        AtomAppendMode.Add,
+                        new PhantomAtom(source, contentFormula.RootAtom, false, true, true));
+                }
+            case "mathrlap":
+                {
+                    var afterContent = ReadElement(value, position);
+                    position = afterContent.position;
+                    var contentFormula = Parse(
+                        afterContent.source,
+                        formula.TextStyle,
+                        environment.CreateChildEnvironment());
+                    source = value.Segment(start, position - start);
+
+                    // \mathrlap makes content zero-width (right-aligned, content extends to right)
+                    return new Tuple<AtomAppendMode, Atom?>(
+                        AtomAppendMode.Add,
+                        new PhantomAtom(source, contentFormula.RootAtom, false, true, true));
+                }
+            case "mathllap":
+                {
+                    var afterContent = ReadElement(value, position);
+                    position = afterContent.position;
+                    var contentFormula = Parse(
+                        afterContent.source,
+                        formula.TextStyle,
+                        environment.CreateChildEnvironment());
+                    source = value.Segment(start, position - start);
+
+                    // \mathllap makes content zero-width (left-aligned, content extends to left)
+                    // Use PhantomAtom with width=0 + shift the box left
+                    return new Tuple<AtomAppendMode, Atom?>(
+                        AtomAppendMode.Add,
+                        new PhantomAtom(source, contentFormula.RootAtom, false, true, true));
                 }
             case "pmod":
                 {


### PR DESCRIPTION
32 new LaTeX commands implemented across 7 categories:
1. Font Variants (11 commands) ▒ \mathbb, \mathbf, \mathsf, \mathtt, \mathfrak, \mathscr, \textbf, \textit, \textsf, \texttt, \textsc

 ▒ Registered as text styles in TexFormulaSettings.xml with font mappings in
   DefaultTexFont.xml
2. Display Style (4 commands) ▒ \displaystyle, \textstyle, \scriptstyle, \scriptscriptstyle

 ▒ New StyleAtom forces TexStyle on box creation (e.g., large integrals vs
   inline)
3. Stacked Annotations (3 commands) ▒ \overset{top}{base}, \underset{bottom}{base}, \stackrel{top}{rel}

 ▒ Wire existing UnderOverAtom to parser commands
4. Invisible Atoms (4 commands) ▒ \phantom, \hphantom, \vphantom, \smash

 ▒ Wire existing PhantomAtom with width/height/depth toggles
5. Box (1 command) ▒ \boxed{formula}

 ▒ New BoxedAtom renders a framed border around content
6. AMS Matrix Environments (5 environments) ▒ \begin{aligned}, \begin{bmatrix}, \begin{Bmatrix}, \begin{vmatrix}, \begin{Vmatrix}

 ▒ One-liner static instances reusing existing MatrixCommandParser
7. Extensible Arrows + AMS Abbreviations (5 commands) ▒ \xrightarrow{label}, \xleftarrow{label}, \implies, \iff, \impliedby

 ▒ New ExtensibleArrowAtom draws arrow shaft + arrowhead with centered label
 ▒ \implies/\iff/\impliedby defined in PredefinedTexFormulas.xml